### PR TITLE
Add publicApi site config parameter

### DIFF
--- a/public_html/quickstatements.js
+++ b/public_html/quickstatements.js
@@ -77,7 +77,7 @@ var QuickStatements = {
 
 	getSiteAPI : function () {
 		var me = this ;
-		return me.sites[me.site].api ;
+		return me.sites[me.site].publicApi || me.sites[me.site].api ;
 	} ,
 	
 	getSitePageURL : function ( page ) {

--- a/public_html/vue.js
+++ b/public_html/vue.js
@@ -29,12 +29,14 @@ $(document).ready ( function () {
                 } , 'json' ) ;
             } )
     ] ) .then ( () => {
-        wd_link_base = config.sites[config.site].pageBase ;
+        const siteConfig = config.sites[config.site] ;
+        const apiUrl = siteConfig.publicApi || siteConfig.api ;
+        wd_link_base = siteConfig.pageBase ;
         wd_link_wd = wd ;
-        wd.api = config.sites[config.site].api + '?callback=?' ;
+        wd.api = apiUrl + '?callback=?' ;
         wd_ns_prefixes = {} ;
-        for ( var letter in config.sites[config.site].types )
-            wd_ns_prefixes[letter] = config.sites[config.site].types[letter].ns_prefix ;
+        for ( var letter in siteConfig.types )
+            wd_ns_prefixes[letter] = siteConfig.types[letter].ns_prefix ;
 
         const routes = [
           { path: '/', component: MainPage , props:true },

--- a/public_html/vue_components/batch.html
+++ b/public_html/vue_components/batch.html
@@ -183,10 +183,11 @@ let BatchPage = Vue.extend ( {
     		let pb = config.sites[me.meta.batch.site].pageBase ;
     		if ( wd_link_base == pb ) return ;
 
+			const apiUrl = config.sites[me.meta.batch.site].publicApi || config.sites[me.meta.batch.site].api ;
 			wd = new WikiData() ;
 	        wd_link_base = pb ;
 	        wd_link_wd = wd ;
-	        wd.api = config.sites[me.meta.batch.site].api + '?callback=?' ;
+	        wd.api = apiUrl + '?callback=?' ;
     	} ,
     	loadTempFile : function ( tmpfile ) {
     		var me = this ;


### PR DESCRIPTION
This adds a new `publicApi` config parameter, that can be used in combination with the existing `publicMwOAuthUrl`, to make quickstatements work correctly when run from https://github.com/wmde/wikibase-docker

Without this fix, quickstatements in wikibase-docker would not be able to [fetch entitity data](https://github.com/magnusmanske/quickstatements/blob/e1f0a86b85bde4942197377e2617e04cf1c376a6/public_html/quickstatements.js#L504), as it tried to query the not-publicly available URL http://wikibase.svc/w/api.php .


I replaced all references to `config.sites[me.meta.batch.site].api` with `config.sites[me.meta.batch.site].publicApi || config.sites[me.meta.batch.site].api`. Also in `public_html/vue.js` and `public_html/vue_components/batch.html`, even though I'm not sure if these are in use.
