### PR TITLE
Add entityBase and use it for quantity units

### DIFF
--- a/public_html/config.json.template
+++ b/public_html/config.json.template
@@ -9,6 +9,7 @@
 			"server" : "www.wikidata.org" ,
 			"api" : "https://www.wikidata.org/w/api.php" ,
 			"pageBase" : "https://www.wikidata.org/wiki/" ,
+			"entityBase" : "http://www.wikidata.org/entity/" ,
 			"toolBase" : "https://quickstatements.toolforge.org" ,
 			"types" : {
 				"P" : { "type":"property" , "ns":120 , "ns_prefix":"Property:" } ,
@@ -20,6 +21,7 @@
 			"oauth" : { "language":"wikidata" , "project":"wikidata" , "ini_file":"/home/factgrid/quickstatements/oauth.ini" , "mwOAuthUrl":"https://database.factgrid.de/index.php?title=Special:OAuth" , "mwOAuthIW":"" } ,
 			"api" : "https://database.factgrid.de/api.php" ,
 			"pageBase" : "https://database.factgrid.de/index.php/" ,
+			"entityBase" : "https://database.factgrid.de/entity/" ,
 			"toolBase" : "https://database.factgrid.de/quickstatements" ,
 			"types" : {
 				"P" : { "type":"property" , "ns":122 , "ns_prefix":"Property:" } ,

--- a/public_html/quickstatements.php
+++ b/public_html/quickstatements.php
@@ -1491,7 +1491,7 @@ exit ( 1 ) ; // Force bot restart
 		if ( preg_match ( '/^([\+\-]{0,1}\d+(\.\d+){0,1})(U(\d+)){0,1}$/' , $v , $m ) ) { // Quantity
 			$cmd['datavalue'] = array ( "type"=>"quantity" , "value"=>array(
 				"amount" => $m[1] ,
-				"unit" => isset( $m[4] ) ? "http://www.wikidata.org/entity/Q{$m[4]}" : "1"
+				"unit" => isset( $m[4] ) ? "{$this->getSite()->entityBase}Q{$m[4]}" : "1"
 			) ) ;
 			return true ;
 		}
@@ -1502,7 +1502,7 @@ exit ( 1 ) ; // Force bot restart
 				"amount" => $m[1] , // use $m[1] (string) instead of $value (float) to avoid precision problems
 				"upperBound" => $value+$error ,
 				"lowerBound" => $value-$error ,
-				"unit" => isset( $m[6] ) ? "http://www.wikidata.org/entity/Q{$m[6]}" : "1"
+				"unit" => isset( $m[6] ) ? "{$this->getSite()->entityBase}Q{$m[6]}" : "1"
 			) ) ;
 			return true ;
 		}


### PR DESCRIPTION
Unlike time calendars and geographic coordinate globes, quantity units are usually specified on the local Wikibase, so they should not be hard-coded for Wikidata. Introduce a new config setting for the .../entity/ base path.