### PR TITLE
Support for manually confirmed users

### DIFF
--- a/public_html/vue_components/batch.html
+++ b/public_html/vue_components/batch.html
@@ -129,7 +129,7 @@ div.create_batch_box > div {
 			<div v-else>
 				You can't create a new batch, because you are
 				<span v-if='!user.is_logged_in'>not logged in</span>
-				<span v-if='!user.isAutoconfirmed()'>not autoconfirmed</span>
+				<span v-if='!user.isAutoconfirmed() || !user.isConfirmed()'>not autoconfirmed</span>
 				<span v-if='user.isBlocked()'>blocked on Wikidata</span>
 			</div>
 		</div>

--- a/public_html/vue_components/user.html
+++ b/public_html/vue_components/user.html
@@ -51,6 +51,10 @@ Vue.component ( 'user' , {
     		if ( !this.is_logged_in ) return '' ;
     		return $.inArray ( 'autoconfirmed' , this.userinfo.groups ) > -1 ;
     	} ,
+       isConfirmed : function () {
+		if ( !this.is_logged_in ) return '' ;
+		return $.inArray ( 'confirmed' , this.userinfo.groups ) > -1 ;
+	} ,
     	isBlocked : function () { // UNTESTED
             console.log(JSON.parse(JSON.stringify(this.userinfo)))
     		if ( typeof this.userinfo.blockid == 'undefined' ) return false ;
@@ -63,7 +67,7 @@ Vue.component ( 'user' , {
             return this.canCreateBatch() ;
         } ,
     	canCreateBatch : function () {
-    		return this.is_logged_in && this.isAutoconfirmed() && !this.isBlocked() ;
+            return this.is_logged_in && ( this.isAutoconfirmed() || this.isConfirmed() ) && !this.isBlocked() ;
     	} ,
     	getUserName : function () {
     		if ( !this.is_logged_in ) return '' ;


### PR DESCRIPTION
Confirmed users have all the same privileges of autoconfirmed users, but instead of based on editing stats it is conferred by a privileged user. This patch treats confirmed users and autoconfirmed users equally.