### PR TITLE
api.php, ignore E_DEPRECATED errors

### DIFF
--- a/public_html/api.php
+++ b/public_html/api.php
@@ -1,6 +1,6 @@
 <?PHP
 
-error_reporting(E_ERROR|E_CORE_ERROR|E_ALL|E_COMPILE_ERROR); // 
+error_reporting(E_ALL ^ E_DEPRECATED); //
 ini_set('display_errors', 'On');
 
 if ( !isset($_REQUEST['openpage']) ) {


### PR DESCRIPTION
These break the API when using later verisons of PHP8 as deprecation warnings are printed. https://github.com/wmde/wikibase-release-pipeline/pull/398#issuecomment-1434823727

As this is hardcoded and can't be overwritten by the php.ini file it's probably worth having a default that is less broken