### PR TITLE
Fix statement creation in CSV mode

### DIFF
--- a/public_html/quickstatements.php
+++ b/public_html/quickstatements.php
@@ -1382,6 +1382,7 @@ exit ( 1 ) ; // Force bot restart
                 if ( $instruction[0] === 'P' ) {
                     $command += [
                         'what' => 'statement',
+                        'new_statement' => 0,
                         'property' => $instruction
                     ];
                     $this->parseValueV1( $value, $command );


### PR DESCRIPTION
This was broken by 8d516dea58. The new $statement field 'new_statement' is checked via isset() in getStatementID(), but unconditionally assumed to exist in compressCommands(). However, only importDataFromV1() was taught to create this field, while importDataFromCSV() wasn’t. This meant that parsing CSV statements would produce a PHP warning, which is included in the web response and thus breaks the JSON output.

Fixes #38.

An alternative would be to guard the access in compressCommands(); the easiest option would be the `??` operator, but that was only added in PHP 7.0 and I don’t really want to risk breaking sites that use QuickStatements on older PHP (even though PHP 7.0 has been out for a while already).