### PR TITLE
Don’t try to send incomplete values to the API

### DIFF
--- a/public_html/quickstatements.php
+++ b/public_html/quickstatements.php
@@ -907,6 +907,7 @@ exit ( 1 ) ; // Force bot restart
 	protected function commandAddStatement ( $command , $i , $statement_id ) {
 		// Paranoia
 		if ( isset($statement_id) ) return $this->commandDone ( $command , "Statement already exists as $statement_id" ) ;
+		if ( !isset($command->datavalue->value) ) return $this->commandError ( $command, "Incomplete command parameters" ) ;
 
 		// Execute!
 		$action = array (
@@ -931,6 +932,7 @@ exit ( 1 ) ; // Force bot restart
 		if ( !isset($command->qualifier) ) return $this->commandError ( $command , "Incomplete command parameters" ) ;
 		if ( !isset($command->qualifier->prop) ) return $this->commandError ( $command , "Incomplete command parameters" ) ;
 		if ( !preg_match ( '/^P\d+$/' , $command->qualifier->prop ) ) return $this->commandError ( $command , "Invalid qualifier property {$command->qualifier->prop}" ) ;
+		if ( !isset($command->qualifier->value->value) ) return $this->commandError ( $command, "Incomplete command parameters" ) ;
 
 		// Execute!
 		$action = array (
@@ -957,6 +959,7 @@ exit ( 1 ) ; // Force bot restart
 		// Prep
 		$snaks = array() ;
 		foreach ( $command->sources AS $source ) {
+			if ( !isset($source->value->value) ) return $this->commandError ( $command, "Incomplete command parameters" ) ;
 			$s = array(
 				'snaktype' => $this->getSnakType ( $source->value ) ,
 				'property' => $source->prop ,


### PR DESCRIPTION
If parseValueV1() can’t parse the value, the $cmd it returns will still have a 'datavalue', but there won’t be a 'value' inside it (but rather a 'text', along with 'type'=>'unknown'). This is apparently not checked at any intervening point (neither in the V1 nor CSV formats), and eventually the commandAdd*() methods would try to send the incomplete data to the API, after producing several PHP warnings due to the missing value (several of them inside getSnakType()), which would also break the JSON response as usual.

Work around this by checking if we have a value just before sending the API request. This means that the bad values will still be shown in the batch view in a weird format (raw JSON), but I don’t know how that should be fixed instead. This at least fixes the server-side warnings and makes the batch not stuck indefinitely.