### PR TITLE
fix: Deprecation warning & float to int conversion

### DIFF
--- a/public_html/quickstatements.php
+++ b/public_html/quickstatements.php
@@ -1116,7 +1116,7 @@ exit ( 1 ) ; // Force bot restart
 	}
 	
 	public function runSingleCommand ( $command ) {
-		if ( $this->sleep != 0 ) sleep ( $this->sleep ) ;
+		if ( $this->sleep != 0 ) sleep ( $this->usleep * 1000 ) ;
 		if ( !isset($command) ) return $this->commandError ( $command , "Empty command" ) ;
 		$command->status = 'working' ;
 		if ( isset($command->error) ) unset ( $command->error ) ;


### PR DESCRIPTION
With PHP 8.1, I got this output when running a batch:

```
<br />
<b>Deprecated</b>:  Implicit conversion from float 0.1 to int loses precision in <b>/var/www/html/quickstatements/public_html/quickstatements.php</b> on line <b>1137</b><br />
{"status":"OK","command":{"action":"add","item":"Q2","property":"P1","what":"statement","datavalue":{"type":"wikibase-entityid","value":{"entity-type":"item","id":"Q1"}},"meta":{"message":"","status":"RUN","id":0},"summary":"#temporary_batch_1738321266983","status":"done","message":"Statement already exists as Q2$5A1CDA8E-2620-4665-ADEF-405FAED776A2"},"last_item":""}
```

Which made the UI fail to parse the response.

Thus I looked at the usage of `$this->sleep` and found only this one instance, where it seemed safe to just multiply to microseconds and use `usleep` instead.

