### PR TITLE
fix sleep statement

### DIFF
--- a/public_html/quickstatements.php
+++ b/public_html/quickstatements.php
@@ -1116,7 +1116,7 @@ exit ( 1 ) ; // Force bot restart
 	}
 	
 	public function runSingleCommand ( $command ) {
-		if ( $this->sleep != 0 ) sleep ( $this->usleep * 1000 ) ;
+                if ( $this->sleep != 0 ) usleep ( $this->sleep * 1000 ) ;
 		if ( !isset($command) ) return $this->commandError ( $command , "Empty command" ) ;
 		$command->status = 'working' ;
 		if ( isset($command->error) ) unset ( $command->error ) ;


### PR DESCRIPTION
Unfortunately I made a mistake when transferring my fix to this repo in https://github.com/magnusmanske/quickstatements/pull/58

This is the line how I meant it to add, currently it rightfully throws a warning:
```
<b>Warning</b>:  Undefined property: QuickStatements::$usleep in <b>/var/www/html/quickstatements/public_html/quickstatements.php</b> on line <b>1144</b><br />
```