### PR TITLE
Codex + Modernize QuickStatements interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 /vendor
 /public_html/php
 /public_html/resources
+/public_html/config.json
+/public_html/local_auth.php
+/public_html/oauth.ini
 .phpunit.result.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# QuickStatements contributor guidance
+
+## Hard rules
+
+- Never edit generated or linked files in `public_html/php` or `public_html/resources`.
+- Do not add AI or assistant attribution to commit messages.
+- Keep mobile layouts and touch-friendly interactions in mind.
+- Treat this as a web-facing product: preserve security boundaries and never commit OAuth credentials, tokens, or local configuration.
+- Prefer simple, readable, maintainable changes. Follow SOLID and DRY where they help rather than adding abstraction for its own sake.
+- Add or update tests when the repository has a practical test seam for the change.
+
+## What this is
+
+QuickStatements is a Wikimedia Toolforge application for importing, reviewing, and running batches of Wikidata statements. The active frontend is a Vue 2 single-page application served directly from `public_html/`; the PHP API performs parsing, batch management, OAuth, and Wikidata edits.
+
+## Architecture
+
+### Frontend
+
+- `public_html/index.html` is the application shell and navigation.
+- `public_html/vue.js` loads configuration and Vue components, then creates the hash-based router.
+- `public_html/vue_components/` contains Vue 2 templates and component scripts.
+- `public_html/quickstatements.css` contains the local Vector/Codex-style presentation layer.
+- `public_html/index_old.html` and `public_html/quickstatements.js` are the legacy interface. Leave them alone unless a task explicitly targets the old UI.
+
+### Backend
+
+- `public_html/api.php` is the request dispatcher keyed by `action`.
+- `public_html/quickstatements.php` contains parsing, batch, OAuth, and edit behavior.
+- `bot.php` and `new_job_from_qs.php` support background batch execution.
+- `schema.sql` describes the MariaDB tables used by the tool.
+
+### Shared library and local configuration
+
+- `public_html/php` and `public_html/resources` are generated or linked from the sibling `magnustools` project and are ignored by Git.
+- `public_html/config.json` is local/deployment configuration copied from `config.json.template` and is ignored by Git.
+- OAuth configuration lives outside the repository. Never print, copy into tracked files, or commit consumer secrets or access tokens.
+
+## Working in this codebase
+
+- Vue 2 is used, not Vue 3. Do not introduce Composition API or single-file components without a deliberate migration.
+- There is no frontend build step; edit the served files and reload.
+- Run `git diff --check`, `node --check public_html/vue.js`, and PHP syntax checks for touched PHP files.
+- PHPUnit requires installed Composer dependencies and an appropriate local configuration.
+- Toolforge database and OAuth behavior cannot be fully reproduced by a plain local PHP process; keep local fallbacks isolated from production behavior.
+- Preserve ToolTranslate attributes and rerun `tt.updateInterface` when translated elements are inserted asynchronously.

--- a/public_html/api.php
+++ b/public_html/api.php
@@ -1,12 +1,17 @@
 <?PHP
 
 error_reporting(E_ALL ^ E_DEPRECATED); //
-ini_set('display_errors', 'On');
+ini_set('display_errors', 'Off');
+ini_set('log_errors', 'On');
 
 if ( !isset($_REQUEST['openpage']) ) {
 	header('Content-type: application/json; charset=UTF-8');
 	header("Cache-Control: no-cache, must-revalidate");
 }
+
+// Optional, ignored development bridge for local OAuth testing.
+$local_auth = __DIR__ . '/local_auth.php';
+if ( is_file($local_auth) ) require $local_auth;
 
 require_once ( 'quickstatements.php' ) ;
 
@@ -28,6 +33,14 @@ function fin ( $status = '' ) {
 	}
 	exit ( 0 ) ;
 }
+
+set_exception_handler ( function ( Throwable $error ) {
+	error_log ( (string)$error ) ;
+	$message = ( $_REQUEST['action'] ?? '' ) == 'run_single_command'
+		? 'Could not complete the command.'
+		: 'Could not complete the request.' ;
+	fin ( $message ) ;
+} ) ;
 
 function get_origin() {
 	$origin = '' ;
@@ -126,6 +139,11 @@ if ( $action == 'import' ) {
 		}
 	}
 
+} else if ( $action == 'logout' ) {
+
+	$qs->getOA()->logout() ;
+	$out['data'] = (object) [ 'is_logged_in' => false ] ;
+
 } else if ( $action == 'oauth_redirect' ) {
 
 	$oa = $qs->getOA() ;
@@ -203,7 +221,9 @@ if ( $action == 'import' ) {
 
 	$db = $qs->getDB() ;
 	$sql = "SELECT * FROM command WHERE batch_id={$batch_id} AND num>={$start}" ; // num BETWEEN {$start} AND {$end}
-	if ( $filter != '' ) {
+	if ( strtoupper(trim($filter)) == 'UNCHANGED' ) {
+		$sql .= " AND `status`='DONE' AND (`message` LIKE '%already exists%' OR `message` LIKE '%already has%' OR `message` LIKE '%has already a qualifier%')" ;
+	} else if ( $filter != '' ) {
 		$filter = explode ( ',' , $filter ) ;
 		foreach ( $filter AS $k => $v ) {
 			$v = $db->real_escape_string ( trim ( strtoupper ( $v ) ) ) ;

--- a/public_html/config.json.template
+++ b/public_html/config.json.template
@@ -5,6 +5,7 @@
 	"valid_origin" : "https://quickstatements.toolforge.org" ,
 	"sites" : {
 		"wikidata" : {
+			"label" : "Wikidata" ,
 			"oauth" : { "language":"wikidata" , "project":"wikidata" , "ini_file":"/data/project/quickstatements/oauth.ini" , "mwOAuthUrl":"https://www.mediawiki.org/w/index.php?title=Special:OAuth" , "mwOAuthIW":"mw" } ,
 			"server" : "www.wikidata.org" ,
 			"api" : "https://www.wikidata.org/w/api.php" ,
@@ -15,6 +16,18 @@
 				"P" : { "type":"property" , "ns":120 , "ns_prefix":"Property:" } ,
 				"Q" : { "type":"item" , "ns":0 , "ns_prefix":"" },
 				"L" : { "type":"lexeme", "ns": 146, "ns_prefix":"Lexeme:" }
+			}
+		}  ,
+		"commons" : {
+			"label" : "Wikimedia Commons" ,
+			"oauth" : { "language":"commons" , "project":"wikimedia" , "ini_file":"/data/project/quickstatements/oauth.ini" , "mwOAuthUrl":"https://www.mediawiki.org/w/index.php?title=Special:OAuth" , "mwOAuthIW":"mw" } ,
+			"server" : "commons.wikimedia.org" ,
+			"api" : "https://commons.wikimedia.org/w/api.php" ,
+			"pageBase" : "https://commons.wikimedia.org/wiki/" ,
+			"entityBase" : "http://commons.wikimedia.org/entity/" ,
+			"toolBase" : "https://quickstatements.toolforge.org" ,
+			"types" : {
+				"M" : { "type":"mediainfo" , "ns":0 , "ns_prefix":"" }
 			}
 		}  ,
 		"factgrid" : {

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -2,10 +2,14 @@
 <html><head>
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="description" content="QuickStatements imports and runs batches of Wikidata statements.">
 <title tt="toolname"></title>
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/magnustools/resources/html/wikimedia.css">
+<link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/oojs-ui/0.49.2/oojs-ui-wikimediaui.min.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/1.3.1/leaflet.css">
+<link rel="stylesheet" href="quickstatements.css?v=20260714-85">
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>
@@ -13,49 +17,106 @@
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
 <script src="https://tools-static.wmflabs.org/tooltranslate/tt.js"></script>
 <script src="https://tools-static.wmflabs.org/magnustools/resources/js/wikidata.js"></script>
-<script src="https://tools-static.wmflabs.org/magnustools/resources/vue/shared.js"></script>
-
-<style>
-.navthing {
-	padding-top:0.3rem;
-	padding-left:0.2rem;
-}
-#working {
-	display:none;
-}
-</style>
+<script src="vue-component-loader.js?v=20260714-03"></script>
 
 </head>
 
-<body>
-	<div id='app' class='container-fluid'>
-		<tool-navbar>
-			<template slot='left'>
-				<li class="nav-item navthing">
-					<router-link class='btn btn-outline-primary' to='/batch/new' tt='new_batch'></router-link>
+<body class="qs-shell">
+	<div id='app' class='container-fluid qs-page' v-cloak>
+		<nav class="navbar navbar-expand-lg navbar-light qs-site-header" aria-label="Tool navigation">
+			<a href="#/" class="navbar-brand qs-wordmark">
+				<span class="qs-wordmark__text">
+					<strong>QuickStatements</strong>
+					<small>Wikidata batch editor</small>
+				</span>
+			</a>
+			<router-link v-show="authLoaded && isLoggedIn" class="btn qs-mobile-new-batch" to="/batch/new" aria-label="New batch">
+				<svg class="cdx-icon cdx-icon--bidi-neutral cdxIconArticleAdd" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M11 9h3v2h-3v3H9v-3H6V9h3V6h2z"></path><path d="M18 1v18H2V1zM4 3v14h12V3z"></path></g></svg>
+				<span class="qs-mobile-new-batch__full" aria-hidden="true">New batch</span>
+				<span class="qs-mobile-new-batch__short" aria-hidden="true">Batch</span>
+			</router-link>
+			<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#qsNavbar"
+				aria-controls="qsNavbar" aria-expanded="false" aria-label="Toggle navigation">
+				<svg class="cdx-icon cdx-icon--bidi-neutral cdxIconMenu" xmlns="http://www.w3.org/2000/svg"
+					width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M18 16H2v-2h16zm0-5H2V9h16zm0-5H2V4h16z"></path></g></svg>
+			</button>
+			<div class="collapse navbar-collapse" id="qsNavbar">
+				<ul class="navbar-nav qs-nav-menu">
+					<li class="nav-item qs-nav-language">
+						<span class="qs-language-icon" aria-hidden="true">
+							<svg class="cdx-icon cdx-icon--bidi-neutral cdxIconLanguage" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="m17.835 19-1.248-3h-4.174l-1.248 3.001H9l4.577-11.005h1.846L20 19zm-4.59-5h2.51L14.5 10.982zM7.618 3H12v2H9.991a8.5 8.5 0 0 1-1.423 4.02q-.24.358-.528.707.634.367 1.379.711l.908.42-.839 1.816-.907-.42a18 18 0 0 1-2.026-1.09c-1.255.979-2.912 1.8-5.076 2.31l-.973.228-.458-1.946.973-.23c1.631-.383 2.885-.954 3.85-1.608C3.29 8.527 2.317 6.884 2.065 5H0V3h5.382l-.724-1.447 1.79-.895L7.617 3ZM4.094 5c.243 1.282.974 2.489 2.29 3.586A6.54 6.54 0 0 0 7.98 5z"/></svg>
+						</span>
+						<div id="tooltranslate_wrapper"></div>
+					</li>
+					<li class="nav-item qs-nav-user" v-show="authLoaded && isLoggedIn"><user></user></li>
+				<template v-if="authLoaded && isLoggedIn">
+					<li class="nav-item qs-nav-item qs-nav-new-batch">
+						<router-link class="qs-nav-link" to="/batch/new">
+							<svg class="cdx-icon cdx-icon--bidi-neutral cdxIconArticleAdd" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M11 9h3v2h-3v3H9v-3H6V9h3V6h2z"></path><path d="M18 1v18H2V1zM4 3v14h12V3z"></path></g></svg>
+							<span>New batch</span>
+						</router-link>
+					</li>
+					<li class="nav-item qs-nav-item">
+						<router-link class="qs-nav-link" :to="'/batches/'+userinfo.name">
+							<svg class="cdx-icon cdx-icon--flip-for-rtl cdxIconUserContributions" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M16.143 13.063c1.578 0 2.857 1.259 2.857 2.812V17h-8v-1.125c0-1.553 1.28-2.813 2.857-2.813h2.286ZM9 16H2v-2h7zm6-8c1.105 0 2 .881 2 1.969 0 1.087-.895 1.969-2 1.969s-2-.882-2-1.97C13 8.882 13.895 8 15 8m-4 3H2V9h9zm7-5H2V4h16z"></path></g></svg>
+							<span>Your batches</span>
+						</router-link>
+					</li>
+				</template>
+				<li class="nav-item qs-nav-item">
+					<router-link class="qs-nav-link" to="/batches">
+						<svg class="cdx-icon cdx-icon--bidi-neutral cdxIconClock" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M10.5 10h4v2h-6V5.5h2z"></path><path d="M10 1a9 9 0 110 18 9 9 0 010-18m0 2a7 7 0 100 14 7 7 0 000-14"></path></g></svg>
+						<span>Latest batches</span>
+					</router-link>
 				</li>
-				<li class="nav-item navthing">
-					<router-link class='btn btn-outline-secondary' to='/batches' tt="show_last_batches"></router-link>
+				<li class="nav-item qs-nav-item">
+					<a class="qs-nav-link" href="https://www.wikidata.org/wiki/Help:QuickStatements" target="_blank" rel="noopener">
+						<span class="cdx-icon cdx-icon--medium cdx-icon--flip-for-rtl cdxIconHelpNotice"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M11 15.5H9v-2h2zm-1-11c1.015 0 1.787.469 2.283 1.074.473.576.717 1.299.717 1.926 0 .68-.174 1.242-.467 1.706-.283.448-.646.753-.933.969-.136.101-.29.208-.385.276a3 3 0 00-.215.166v.883H9v-1c0-.645.346-1.08.637-1.347a4 4 0 01.414-.327c.139-.1.235-.165.35-.25.212-.16.349-.293.44-.438.083-.13.159-.319.159-.638 0-.152-.076-.43-.264-.658A.9.9 0 0010 6.5c-.282 0-.518.133-.714.375C9.066 7.146 9 7.43 9 7.5H7c0-.611.28-1.327.733-1.886C8.211 5.026 8.975 4.5 10 4.5"></path><path d="M10 1a9 9 0 110 18 9 9 0 010-18m0 2a7 7 0 100 14 7 7 0 000-14"></path></g></svg></span>
+						<span>Help</span>
+					</a>
 				</li>
-				<li class="nav-item navthing">
-					<a class='btn btn-outline-secondary' target='_blank' href='https://www.wikidata.org/wiki/User:Magnus_Manske/quick_statements2' tt='brainstorming'></a>
-				</li>
-				<li class="nav-item navthing">
-					<a class='btn btn-outline-secondary' target='_blank' href='https://github.com/magnusmanske/quickstatements' tt='git'></a>
-				</li>
-				<li class="nav-item navthing">
-					<a class='btn btn-outline-info' target='_blank' href='https://www.wikidata.org/wiki/Help:QuickStatements' tt='help'></a>
-				</li>
-				<li class="nav-item navthing" id='working'>
-					<img src='https://upload.wikimedia.org/wikipedia/commons/c/cd/Vector_Loading_fallback.gif' />
-				</li>
-			</template>
-			<template slot='right'><user></user></template>
-		</tool-navbar>
-		<router-view :key="$route.path"><i tt='loading'></i></router-view>
+				</ul>
+			</div>
+		</nav>
+
+		<main class="qs-main">
+			<div id="qs-startup-error" class="qs-notice qs-notice--warning" role="alert" hidden>
+				Could not finish loading. Please reload the page and try again.
+			</div>
+			<div v-if="!authLoaded" class="qs-loading" aria-live="polite" aria-busy="true">
+				<div class="cdx-progress-bar cdx-progress-bar--inline" role="progressbar" aria-label="Checking login"><div class="cdx-progress-bar__bar"></div></div>
+			</div>
+			<section v-else-if="!isLoggedIn" class="qs-login" aria-labelledby="qs-login-title">
+				<h1 id="qs-login-title">QuickStatements</h1>
+				<p>Import and run batches of QuickStatements</p>
+				<a href="./api.php?action=oauth_redirect"
+					class="oo-ui-buttonElement oo-ui-widget oo-ui-widget-enabled oo-ui-buttonElement-framed oo-ui-flaggedElement-primary oo-ui-flaggedElement-progressive qs-login-button">
+					<span class="oo-ui-buttonElement-button" role="button">
+						<span class="oo-ui-labelElement-label" lang="en">Log in</span>
+					</span>
+				</a>
+			</section>
+			<router-view v-else :key="$route.path"></router-view>
+		</main>
 	</div>
+	<div id="working" class="qs-global-working" aria-live="polite" aria-busy="true">
+		<div class="cdx-progress-bar cdx-progress-bar--inline" role="progressbar" aria-label="Loading…"><div class="cdx-progress-bar__bar"></div></div>
+	</div>
+
+	<footer class="qs-footer">
+		<hr>
+		<ul class="qs-footer-links">
+			<li><a href="https://www.wikidata.org/wiki/Help:QuickStatements">Help</a></li>
+			<li><a href="https://www.wikidata.org/wiki/User:Magnus_Manske/quick_statements2">Discuss</a></li>
+			<li><a href="https://tooltranslate.toolforge.org/#tool=24">Translate</a></li>
+			<li><a href="https://github.com/magnusmanske/quickstatements">Source</a></li>
+			<li><a href="https://github.com/magnusmanske/quickstatements/issues" aria-label="Report issues"><span class="qs-report-issues-full" aria-hidden="true">Report issues</span><span class="qs-report-issues-short" aria-hidden="true">Issues</span></a></li>
+		</ul>
+		<p><a href="https://toolsadmin.wikimedia.org/">Powered by Wikimedia Toolforge</a></p>
+		<p><bdi dir="ltr">Code licensed <a href="https://www.gnu.org/licenses/gpl-3.0.html" rel="license">GPLv3</a></bdi></p>
+	</footer>
 </body>
 
-<script src="vue.js"></script>
+<script src="vue.js?v=20260714-08"></script>
 
 </html>

--- a/public_html/index_old.html
+++ b/public_html/index_old.html
@@ -69,6 +69,14 @@ a.red {
 #mode_batches {
 	display:none;
 }
+#qs_old_notice {
+	display:none;
+	margin:12px 15px;
+	padding:8px 12px;
+	border:1px solid #c8ccd1;
+	border-left:3px solid #bf3c2c;
+	background:#fff;
+}
 </style>
 
 </head>
@@ -128,6 +136,8 @@ a.red {
   </ul>
 
 </nav>
+
+<div id="qs_old_notice" role="alert"></div>
 
 
 <div id='mode_token' class="container-fluid mode">

--- a/public_html/quickstatements.css
+++ b/public_html/quickstatements.css
@@ -1,0 +1,1491 @@
+:root {
+	--qs-category-blue-600: #4b77d6;
+	--qs-category-yellow-300: #edb537;
+	--qs-category-red-400: #fd7865;
+	--qs-category-green-300: #80cdb3;
+	--qs-category-lime-500: #259948;
+	--qs-category-blue-300: #a6bbf5;
+	--qs-category-purple-500: #8d7ebd;
+	--qs-category-pink-300: #d9b4cd;
+	--qs-category-yellow-500: #ab7f2a;
+	--qs-category-gray-400: #a2a9b1;
+	--qs-option-red: #bf3c2c;
+	--qs-option-lime: #1f7a39;
+	--qs-option-green: #177860;
+	--qs-option-purple: #6a60b0;
+	--qs-background-option-red: #ffe9e5;
+	--qs-background-option-lime: #e3f2e4;
+	--qs-background-option-green: #dff2eb;
+	--qs-background-option-purple: #f0ecf6;
+	--qs-border: #a2a9b1;
+	--qs-border-subtle: #eaecf0;
+	--qs-background-neutral: #eaecf0;
+	--qs-progressive: #36c;
+	--qs-progressive-hover: #447ff5;
+	--qs-progressive-active: #233566;
+	--qs-link-hover: #3056a9;
+	--qs-destructive: #bf3c2c;
+	--qs-content-added: #006400;
+	--qs-icon-success: #099979;
+	--qs-background-success-subtle: #dff2eb;
+	--qs-text: #202122;
+	--qs-subtle: #54595d;
+	--qs-font-base: sans-serif;
+	--qs-font-heading: 'Linux Libertine', 'Georgia', 'Times', 'Source Serif 4', serif;
+	--qs-font-monospace: 'Menlo', 'Consolas', 'Liberation Mono', 'Fira Code', 'Courier New', monospace;
+	--qs-font-size-x-small: 0.75rem;
+	--qs-font-size-small: 0.875rem;
+	--qs-font-size-medium: 1rem;
+	--qs-font-size-large: 1.125rem;
+	--qs-font-size-x-large: 1.25rem;
+	--qs-font-size-xx-large: 1.5rem;
+	--qs-font-size-xxx-large: 1.75rem;
+	--qs-line-height-x-small: 1.25rem;
+	--qs-line-height-small: 1.375rem;
+	--qs-line-height-medium: 1.625rem;
+	--qs-line-height-large: 1.75rem;
+	--qs-line-height-x-large: 1.875rem;
+	--qs-line-height-xx-large: 2.125rem;
+	--qs-line-height-xxx-large: 2.375rem;
+	--qs-font-weight-normal: 400;
+	--qs-font-weight-semi-bold: 600;
+	--qs-font-weight-bold: 700;
+}
+
+.qs-action-badge {
+	display: inline-flex;
+	box-sizing: border-box;
+	min-height: 20px;
+	max-width: 100%;
+	align-items: center;
+	padding: 1px 6px;
+	border: 1px solid transparent;
+	border-radius: 9999px;
+	font-size: var(--qs-font-size-x-small);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: 1rem;
+	letter-spacing: normal;
+	text-transform: capitalize;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.qs-action-badge--add {
+	border-color: var(--qs-option-green);
+	background: var(--qs-background-option-green);
+	color: var(--qs-text);
+}
+
+.qs-action-badge--create {
+	border-color: var(--qs-option-lime);
+	background: var(--qs-background-option-lime);
+	color: var(--qs-text);
+}
+
+.qs-action-badge--merge {
+	border-color: var(--qs-option-purple);
+	background: var(--qs-background-option-purple);
+	color: var(--qs-text);
+}
+
+.qs-action-badge--remove {
+	border-color: var(--qs-option-red);
+	background: var(--qs-background-option-red);
+	color: var(--qs-text);
+}
+
+.qs-action-badge--unknown {
+	border-color: var(--qs-category-gray-400);
+	background: #eaecf0;
+	color: #202122;
+}
+
+.qs-status-badge--done {
+	border: 1px solid var(--qs-content-added);
+	background: var(--qs-background-success-subtle);
+	color: var(--qs-content-added);
+}
+
+.qs-status-badge--run {
+	border: 1px solid var(--qs-progressive-active);
+	background: var(--qs-progressive-active);
+	color: #fff;
+}
+
+.qs-status-badge--compact {
+	padding: 2px 4px;
+}
+
+html,
+body {
+	min-height: 100%;
+}
+
+body.qs-shell {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+	margin: 0;
+	color: var(--qs-text);
+	background: #fff;
+	font-family: var(--qs-font-base);
+	font-size: var(--qs-font-size-medium);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-medium);
+	text-align: start;
+}
+
+button,
+input,
+select,
+textarea {
+	font-family: var(--qs-font-base);
+}
+
+.qs-page {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	width: 100%;
+	max-width: 1200px;
+	padding-inline: 16px;
+}
+
+.qs-main {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	padding-block: 24px 40px;
+	text-align: start;
+}
+
+.qs-notice {
+	padding: 12px 16px;
+	border: 1px solid;
+	border-radius: 2px;
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-notice--warning {
+	border-color: #fc3;
+	background: #fef6e7;
+	color: var(--qs-text);
+}
+
+[v-cloak] .qs-site-header,
+[v-cloak] .qs-login,
+[v-cloak] router-view {
+	display: none;
+}
+
+.navthing {
+	padding-top: 0.3rem;
+	padding-inline-start: 0.2rem;
+}
+
+#working {
+	display: none;
+}
+
+.qs-global-working {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 4px 16px 12px;
+}
+
+body.qs-is-working .qs-main {
+	padding-bottom: 0;
+}
+
+.qs-global-working .cdx-progress-bar {
+	width: 100%;
+	height: 4px;
+	margin: 0;
+}
+
+/* Vector-style tool header, matching the flickr2commons navigation shell. */
+.qs-page > nav.navbar {
+	min-height: 64px;
+	margin: 0 -8px;
+	padding: 8px;
+	border-bottom: 1px solid var(--qs-border-subtle);
+	background: #fff !important;
+	font-family: var(--qs-font-base);
+}
+
+.qs-page > nav a,
+.qs-page > nav button,
+.qs-page > nav select {
+	font-family: var(--qs-font-base);
+}
+
+.qs-page > nav .navbar-collapse,
+.qs-page > nav .navbar-nav {
+	align-items: center;
+}
+
+.qs-page > nav .navbar-collapse {
+	flex-grow: 0;
+}
+
+.qs-wordmark {
+	display: inline-flex;
+	align-items: center;
+	margin-inline-end: auto;
+	padding: 2px 0;
+	padding-inline-end: 12px;
+	color: var(--qs-text) !important;
+	line-height: 1.1;
+}
+
+.qs-wordmark__text {
+	display: flex;
+	flex-direction: column;
+}
+
+.qs-wordmark strong {
+	font-size: var(--qs-font-size-x-large);
+	font-weight: var(--qs-font-weight-bold);
+}
+
+.qs-wordmark small {
+	margin-top: 2px;
+	color: var(--qs-subtle);
+	font-family: var(--qs-font-monospace);
+	font-size: var(--qs-font-size-x-small);
+	font-weight: var(--qs-font-weight-normal);
+	letter-spacing: 0.099em;
+}
+
+.qs-page > nav .qs-nav-menu {
+	gap: 2px;
+	padding-inline-start: 0;
+}
+
+.qs-page > nav .qs-nav-item {
+	order: 1;
+}
+
+.qs-page > nav .qs-nav-language {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	order: 2;
+	margin-inline-start: auto;
+	padding-inline-start: 8px;
+}
+
+.qs-page > nav .qs-nav-user {
+	order: 3;
+}
+
+.qs-language-icon {
+	display: inline-flex;
+	flex: 0 0 20px;
+	align-items: center;
+	color: var(--qs-subtle);
+}
+
+.qs-language-icon svg {
+	width: 20px;
+	height: 20px;
+	fill: currentColor;
+}
+
+.qs-page > nav #tooltranslate_wrapper form {
+	display: flex !important;
+	align-items: center;
+	gap: 4px;
+}
+
+.qs-page > nav #tooltranslate_wrapper select {
+	width: auto;
+	max-width: 7rem;
+	height: 32px;
+	padding-block: 3px;
+	border-color: var(--qs-border);
+	border-radius: 2px;
+	background-color: #fff;
+	font-size: var(--qs-font-size-small);
+}
+
+.qs-page > nav #tooltranslate_wrapper a {
+	display: none;
+}
+
+.qs-page > nav .navthing {
+	margin-inline-start: 4px;
+	padding: 0;
+}
+
+.qs-page > nav .navthing .btn,
+.qs-page > nav .qs-nav-user .btn {
+	min-height: 40px;
+	padding: 9px 12px;
+	border: 0;
+	background: transparent;
+	color: var(--qs-text) !important;
+	font-weight: var(--qs-font-weight-semi-bold);
+}
+
+.qs-page > nav .navthing .btn:hover,
+.qs-page > nav .navthing .btn:focus,
+.qs-page > nav .qs-nav-user .btn:hover,
+.qs-page > nav .qs-nav-user .btn:focus {
+	background: #f8f9fa;
+	box-shadow: none;
+}
+
+.qs-page > nav #navbarSupportedContent > a:last-child {
+	display: none;
+}
+
+.qs-page > nav .qs-nav-item {
+	display: flex;
+	align-items: center;
+	margin: 0;
+	padding: 0;
+}
+
+.qs-page > nav .qs-nav-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-height: 32px;
+	padding: 4px 8px;
+	border-radius: 2px;
+	color: var(--qs-subtle);
+	font-size: var(--qs-font-size-small);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-small);
+	white-space: nowrap;
+}
+
+.qs-page > nav .qs-nav-link:hover,
+.qs-page > nav .qs-nav-link:focus {
+	background: #f8f9fa;
+	color: var(--qs-text);
+	text-decoration: none;
+}
+
+.qs-page > nav .qs-nav-link .cdx-icon {
+	flex: 0 0 16px;
+	width: 16px;
+	height: 16px;
+	fill: currentColor;
+}
+
+.qs-page > nav .qs-nav-link .cdxIconUserTalk,
+.qs-page > nav .qs-nav-link .cdxIconUserActive,
+.qs-page > nav .qs-nav-link .cdxIconArticleAdd,
+.qs-page > nav .qs-nav-link .cdxIconClock,
+.qs-page > nav .qs-nav-link .cdxIconUserContributions,
+.qs-page > nav .qs-nav-link .cdxIconHelpNotice {
+	flex-basis: 20px;
+	width: 20px;
+	height: 20px;
+}
+
+.qs-page > nav .qs-nav-link--authorized {
+	color: var(--qs-text);
+	font-weight: var(--qs-font-weight-semi-bold);
+}
+
+.qs-page > nav .qs-nav-user > div {
+	display: flex;
+	min-width: 0;
+}
+
+.qs-user-session {
+	align-items: center;
+}
+
+.qs-nav-logout {
+	flex: 0 0 auto;
+	margin-inline-start: 4px;
+	padding: 4px 8px;
+	border: 0;
+	background: transparent;
+	color: var(--qs-progressive);
+	font: inherit;
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+	cursor: pointer;
+}
+
+.qs-nav-logout:hover,
+.qs-nav-logout:focus {
+	background: var(--qs-background-interactive-subtle, #f8f9fa);
+	text-decoration: underline;
+}
+
+.qs-page > nav .qs-nav-user .cdxIconUserActive {
+	fill: var(--qs-subtle);
+}
+
+.qs-nav-user-name {
+	max-width: 8em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.cdx-icon {
+	transform-origin: center;
+}
+
+html[dir="rtl"] .cdx-icon--flip-for-rtl {
+	transform: scaleX(-1);
+}
+
+html[dir="rtl"][lang|="he"] .cdxIconHelpNotice,
+html[dir="rtl"][lang|="yi"] .cdxIconHelpNotice {
+	transform: none;
+}
+
+html[dir="rtl"] .cdx-icon--bidi-neutral {
+	transform: none;
+}
+
+html[dir="rtl"] #tooltranslate_wrapper select {
+	padding-right: 3px;
+	padding-left: 18px;
+	background-position: left 4px center;
+}
+
+.qs-page > nav .navbar-toggler {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	padding: 9px;
+	border-color: var(--qs-border);
+	border-radius: 2px;
+}
+
+.qs-page > nav .navbar-toggler .cdx-icon {
+	width: 20px;
+	height: 20px;
+	fill: currentColor;
+}
+
+.qs-mobile-new-batch {
+	display: none;
+}
+
+.qs-mobile-new-batch .cdx-icon {
+	width: 20px;
+	height: 20px;
+	margin-inline-end: 6px;
+	fill: currentColor;
+}
+
+@media (max-width: 991px) {
+	html[dir="rtl"] .qs-page > nav.navbar {
+		justify-content: flex-start;
+	}
+
+	html[dir="rtl"] .qs-wordmark {
+		margin-inline-end: 0;
+		margin-right: 0;
+	}
+
+	html[dir="rtl"] .qs-page > nav .navbar-toggler {
+		margin-inline-end: auto;
+	}
+
+	.qs-page > nav .navbar-toggler {
+		display: inline-flex;
+	}
+
+	.qs-mobile-new-batch {
+		display: inline-flex;
+		flex: 0 0 auto;
+		align-items: center;
+		height: 40px;
+		padding-block: 9px;
+		margin-inline-end: 8px;
+	}
+
+	.qs-page > nav .qs-nav-new-batch {
+		display: none;
+	}
+
+	.qs-page > nav .navbar-collapse {
+		margin-top: 8px;
+		padding-top: 8px;
+		border-top: 1px solid var(--qs-border-subtle);
+	}
+
+	.qs-page > nav .navbar-nav {
+		display: grid;
+		width: 100%;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
+	}
+
+	.qs-page > nav .qs-nav-language {
+		display: flex;
+		align-items: center;
+		grid-column: 2;
+		grid-row: 1;
+		height: 41px;
+		margin: 0;
+		padding-block: 4px;
+		padding-inline: 8px 0;
+		order: 2;
+		border-bottom: 1px solid var(--qs-border-subtle);
+	}
+
+	.qs-page > nav .qs-nav-user {
+		grid-column: 1;
+		grid-row: 1;
+		order: 1;
+		min-width: 0;
+		height: 41px;
+		border-bottom: 1px solid var(--qs-border-subtle);
+	}
+
+	.qs-page > nav .qs-nav-user > div,
+	.qs-page > nav .qs-nav-user .qs-nav-link {
+		height: 40px;
+	}
+
+	.qs-page > nav .qs-nav-user .qs-nav-link {
+		flex: 1 1 auto;
+		width: auto;
+		min-width: 0;
+	}
+
+	.qs-page > nav .qs-nav-item {
+		grid-column: 1 / -1;
+		order: 3;
+		width: 100%;
+	}
+
+	.qs-page > nav .qs-nav-link,
+	.qs-page > nav .navthing .btn,
+	.qs-page > nav .qs-nav-user .btn {
+		width: 100%;
+		justify-content: flex-start;
+		min-height: 40px;
+		padding: 8px;
+		font-size: var(--qs-font-size-small);
+	}
+
+	.qs-page > nav #tooltranslate_wrapper select {
+		width: 6.5rem;
+		max-width: 6.5rem;
+	}
+}
+
+.qs-intro-card {
+	display: flex;
+	width: 100%;
+	align-items: flex-end;
+	gap: 24px;
+	padding: 24px;
+	border: 1px solid var(--qs-border-subtle);
+	border-radius: 2px;
+	background: #fff;
+}
+
+.qs-intro-card__content {
+	max-width: 75ch;
+	text-align: start;
+}
+
+.qs-intro-card h1 {
+	margin: 0 0 12px;
+	font-family: var(--qs-font-heading);
+	font-size: var(--qs-font-size-xxx-large);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-xxx-large);
+}
+
+.qs-intro-card p {
+	margin: 0;
+	line-height: var(--qs-line-height-medium);
+}
+
+.qs-intro-card p + p {
+	margin-top: 8px;
+}
+
+.qs-intro-card__action {
+	flex: 0 0 auto;
+	margin-inline-start: auto;
+}
+
+.qs-manage {
+	margin-top: 24px;
+}
+
+.qs-manage h2 {
+	margin: 0 0 12px;
+	font-family: var(--qs-font-heading);
+	font-size: var(--qs-font-size-xx-large);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-xx-large);
+}
+
+.qs-manage-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 16px;
+}
+
+.qs-manage-action {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	align-items: start;
+	gap: 10px;
+	padding: 16px;
+	border: 1px solid var(--qs-border-subtle);
+	border-top: 3px solid var(--qs-progressive);
+	border-radius: 2px;
+	background: #fff;
+	text-align: start;
+}
+
+.qs-manage-action label {
+	margin: 0;
+	font-size: var(--qs-font-size-small);
+	font-weight: var(--qs-font-weight-bold);
+	line-height: var(--qs-line-height-small);
+	text-align: start;
+}
+
+.qs-manage-action .form-control {
+	width: 100%;
+	min-width: 0;
+	height: 32px;
+	padding: 5px 8px;
+	border: 1px solid var(--qs-border) !important;
+	border-radius: 2px;
+	background: #fff;
+	color: var(--qs-text);
+	box-shadow: none;
+}
+
+.qs-manage-action .form-control:hover {
+	border-color: #72777d !important;
+}
+
+.qs-manage-action .form-control:focus {
+	border-color: var(--qs-progressive) !important;
+	outline: 1px solid transparent;
+	box-shadow: inset 0 0 0 1px var(--qs-progressive);
+}
+
+.qs-manage-action .form-control.is-invalid {
+	border-color: var(--qs-destructive) !important;
+}
+
+.qs-manage-action .btn {
+	margin-top: auto;
+}
+
+.qs-login {
+	max-width: 42rem;
+	margin: 7vh auto 0;
+}
+
+.qs-loading,
+.qs-route-loading {
+	display: flex;
+	flex: 1 1 auto;
+	align-items: flex-end;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+}
+
+.qs-loading .cdx-progress-bar,
+.qs-route-loading .cdx-progress-bar {
+	width: 100%;
+}
+
+body:has(.qs-loading) .qs-main,
+body:has(.qs-route-loading) .qs-main {
+	padding-bottom: 24px;
+}
+
+.qs-batches-page {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	width: 100%;
+	text-align: start;
+}
+
+.cdx-progress-bar {
+	position: relative;
+	box-sizing: border-box;
+	width: 100%;
+	overflow: hidden;
+	background-color: var(--qs-border-subtle);
+}
+
+.cdx-progress-bar:not(.cdx-progress-bar--inline) {
+	height: 12px;
+	border: 1px solid var(--qs-progressive);
+	border-radius: 2px;
+	background-color: #fff;
+}
+
+.cdx-progress-bar--inline {
+	height: 4px;
+	border: 0;
+	border-radius: 0;
+}
+
+.cdx-progress-bar__bar {
+	position: absolute;
+	inset-block: 0;
+	inset-inline-start: -25%;
+	width: 25%;
+	background-color: var(--qs-progressive);
+	animation: cdx-progress-bar 1.6s ease-in-out infinite;
+}
+
+@keyframes cdx-progress-bar {
+	from { inset-inline-start: -25%; }
+	to { inset-inline-start: 100%; }
+}
+
+.qs-login {
+	padding: 28px 32px 32px;
+	border: 1px solid var(--qs-border-subtle);
+	border-radius: 2px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.qs-login h1 {
+	margin: 0 0 12px;
+	font-family: var(--qs-font-heading);
+	font-size: var(--qs-font-size-xxx-large);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-xxx-large);
+}
+
+.qs-login p {
+	margin-bottom: 22px;
+	color: var(--qs-subtle);
+	font-size: var(--qs-font-size-medium);
+	line-height: var(--qs-line-height-medium);
+}
+
+.qs-login-button {
+	display: inline-flex;
+	align-items: center;
+	height: 32px;
+	margin: 0;
+	vertical-align: top;
+	font-family: var(--qs-font-base);
+}
+
+.qs-login-button > .oo-ui-buttonElement-button {
+	display: inline-flex !important;
+	align-items: center;
+	box-sizing: border-box;
+	height: 32px !important;
+	min-height: 32px !important;
+	padding: 5px 12px !important;
+	line-height: var(--qs-line-height-x-small);
+}
+
+/* WikimediaUI/OOUI treatment for legacy Bootstrap button markup. */
+.btn {
+	min-height: 32px;
+	padding: 5px 12px;
+	border: 1px solid var(--qs-border);
+	border-radius: 2px;
+	background: #f8f9fa;
+	color: var(--qs-text);
+	font-family: var(--qs-font-base);
+	font-size: var(--qs-font-size-small);
+	font-weight: var(--qs-font-weight-bold);
+	line-height: var(--qs-line-height-x-small);
+	box-shadow: none;
+}
+
+.btn:hover,
+.btn:focus {
+	border-color: #72777d;
+	background: #fff;
+	color: var(--qs-text);
+	text-decoration: none;
+}
+
+.btn:focus,
+.btn.focus {
+	outline: 1px solid transparent;
+	box-shadow: inset 0 0 0 1px var(--qs-progressive);
+}
+
+.btn:active,
+.btn.active {
+	border-color: #72777d;
+	background: #c8ccd1;
+	box-shadow: none;
+}
+
+.btn-primary,
+.btn-outline-primary,
+.btn-success,
+.btn-outline-success {
+	border-color: var(--qs-progressive);
+	background: var(--qs-progressive);
+	color: #fff !important;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-outline-primary:hover,
+.btn-outline-primary:focus,
+.btn-success:hover,
+.btn-success:focus,
+.btn-outline-success:hover,
+.btn-outline-success:focus {
+	border-color: var(--qs-progressive-hover);
+	background: var(--qs-progressive-hover);
+	color: #fff !important;
+}
+
+.btn-primary:active,
+.btn-outline-primary:active,
+.btn-success:active,
+.btn-outline-success:active {
+	border-color: var(--qs-progressive-active);
+	background: var(--qs-progressive-active);
+}
+
+.btn-danger,
+.btn-outline-danger {
+	border-color: var(--qs-destructive);
+	background: #fff;
+	color: var(--qs-destructive);
+}
+
+.btn-danger:hover,
+.btn-outline-danger:hover {
+	border-color: var(--qs-destructive);
+	background: var(--qs-destructive);
+	color: #fff;
+}
+
+.btn:disabled,
+.btn.disabled {
+	border-color: var(--qs-border-subtle);
+	background: #c8ccd1;
+	color: #72777d;
+	opacity: 1;
+	cursor: default;
+}
+
+.btn-lg {
+	min-height: 44px;
+	padding: 9px 16px;
+	font-size: var(--qs-font-size-medium);
+}
+
+/* Codex typography normalization for Bootstrap-era and component-local markup. */
+.qs-main h1,
+.qs-main h2,
+.qs-main h3,
+.qs-main h4 {
+	color: var(--qs-text);
+}
+
+.qs-main h1 {
+	font-family: var(--qs-font-heading);
+	font-size: var(--qs-font-size-xxx-large);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-xxx-large);
+}
+
+.qs-main h2 {
+	font-family: var(--qs-font-heading);
+	font-size: var(--qs-font-size-xx-large);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-xx-large);
+}
+
+.qs-main h3 {
+	font-family: var(--qs-font-base);
+	font-size: var(--qs-font-size-x-large);
+	font-weight: var(--qs-font-weight-bold);
+	line-height: var(--qs-line-height-x-large);
+}
+
+.qs-main h4 {
+	font-family: var(--qs-font-base);
+	font-size: var(--qs-font-size-large);
+	font-weight: var(--qs-font-weight-bold);
+	line-height: var(--qs-line-height-large);
+}
+
+.qs-main .form-control,
+.qs-main .custom-select,
+.qs-main select,
+.qs-main input,
+.qs-main textarea {
+	font-family: var(--qs-font-base);
+	font-size: var(--qs-font-size-medium);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-main code,
+.qs-main pre,
+.qs-main tt,
+.qs-main .command_id {
+	font-family: var(--qs-font-monospace) !important;
+}
+
+.qs-main textarea {
+	font-family: var(--qs-font-monospace) !important;
+	font-size: var(--qs-font-size-small) !important;
+	line-height: var(--qs-line-height-small) !important;
+}
+
+.qs-main code,
+.qs-main pre,
+.qs-main tt,
+.qs-main .command_id {
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-main .table,
+.qs-main .list-group,
+.qs-main .badge,
+.qs-main .batch_status_header,
+.qs-main .command_row {
+	font-family: var(--qs-font-base);
+}
+
+.qs-main .table {
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-main .table th {
+	font-weight: var(--qs-font-weight-semi-bold);
+}
+
+.qs-main .badge,
+.qs-main small,
+.qs-main .small,
+.qs-main .text-muted {
+	font-size: var(--qs-font-size-small);
+	font-weight: var(--qs-font-weight-normal);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-main .batch_status_header > div {
+	font-size: var(--qs-font-size-large);
+	line-height: var(--qs-line-height-large);
+}
+
+.qs-batch-setup {
+	display: flex;
+	align-items: flex-end;
+	gap: 16px;
+	margin-bottom: 12px;
+}
+
+.qs-batch-project {
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.qs-batch-project legend,
+.qs-batch-name label,
+.qs-command-editor label {
+	display: block;
+	width: auto;
+	margin: 0 0 6px;
+	padding: 0;
+	font-size: var(--qs-font-size-small);
+	font-weight: var(--qs-font-weight-bold);
+	line-height: var(--qs-line-height-small);
+	text-align: start;
+}
+
+.qs-radio-buttons {
+	display: inline-flex;
+}
+
+.qs-radio-buttons label {
+	margin: 0;
+	cursor: pointer;
+}
+
+.qs-radio-buttons input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	opacity: 0;
+}
+
+.qs-radio-buttons span {
+	display: inline-flex;
+	min-height: 32px;
+	align-items: center;
+	padding: 5px 12px;
+	border: 1px solid var(--qs-border);
+	background: #f8f9fa;
+	font-size: var(--qs-font-size-small);
+	font-weight: var(--qs-font-weight-bold);
+	line-height: var(--qs-line-height-x-small);
+}
+
+.qs-radio-buttons label + label span {
+	margin-inline-start: -1px;
+}
+
+.qs-radio-buttons label:first-child span {
+	border-start-start-radius: 2px;
+	border-end-start-radius: 2px;
+}
+
+.qs-radio-buttons label:last-child span {
+	border-start-end-radius: 2px;
+	border-end-end-radius: 2px;
+}
+
+.qs-radio-buttons input:checked + span {
+	position: relative;
+	border-color: #72777d;
+	background: #eaecf0;
+}
+
+.qs-command-filters input[value='INIT']:checked + span {
+	border-color: var(--qs-progressive-active);
+	background: var(--qs-progressive-active);
+	color: #fff;
+}
+
+.qs-radio-buttons input:focus + span {
+	position: relative;
+	z-index: 1;
+	outline: 1px solid transparent;
+	box-shadow: inset 0 0 0 1px var(--qs-progressive);
+}
+
+.qs-batch-name {
+	width: min(24rem, 100%);
+}
+
+.qs-batch-name .form-control {
+	width: 100%;
+	height: 32px;
+	border: 1px solid var(--qs-border);
+	border-radius: 2px;
+	box-shadow: none;
+}
+
+.qs-import-help {
+	max-width: 75ch;
+	text-align: start;
+}
+
+.qs-import-actions {
+	margin-top: 8px;
+	text-align: start;
+}
+
+.qs-import-progress {
+	width: 100%;
+	margin-top: 8px;
+}
+
+.qs-batch-view {
+	display: flex;
+	min-height: max(28rem, calc(100vh - 17rem));
+	flex-direction: column;
+}
+
+.qs-command-list {
+	margin-top: 0.5rem;
+}
+
+.qs-batch-commands-panel {
+	padding-top: 4px;
+	border-top: 2px solid var(--qs-border-subtle);
+}
+
+.qs-command-section,
+.qs-command-list,
+.qs-batch-commands-panel,
+.qs-command-list-shell,
+.qs-command-list-content {
+	display: flex;
+	min-height: 0;
+	flex: 1;
+	flex-direction: column;
+}
+
+.qs-run-bar {
+	position: static;
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0 0 8px;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px 16px;
+	padding: 12px 16px;
+	border: 1px solid var(--qs-border);
+	border-radius: 2px;
+	background: var(--qs-background-interactive-subtle, #f8f9fa);
+	box-shadow: none;
+	direction: inherit;
+	text-align: start;
+}
+
+.qs-run-bar__status,
+.qs-run-bar__actions,
+.qs-run-bar__progress-wrap {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+}
+
+.qs-run-bar__actions {
+	flex: 0 0 auto;
+	margin-inline-start: auto;
+	justify-content: flex-end;
+	align-self: center;
+}
+
+.qs-run-bar__status {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
+.qs-run-bar__progress-wrap {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.qs-run-status {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.qs-run-status__icon {
+	width: 20px;
+	height: 20px;
+	fill: var(--qs-icon-success);
+}
+
+.qs-run-legend {
+	display: flex;
+	flex-basis: 100%;
+	align-items: center;
+	gap: 4px;
+	color: var(--qs-subtle);
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-run-followup {
+	flex-basis: 100%;
+	color: var(--qs-subtle);
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-external-action {
+	display: inline;
+	color: var(--qs-progressive);
+}
+
+.qs-external-action:visited {
+	color: var(--qs-progressive);
+}
+
+.qs-external-action:hover,
+.qs-external-action:focus {
+	color: var(--qs-link-hover);
+	text-decoration: underline;
+}
+
+.qs-external-action svg {
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	margin-inline-start: 2px;
+	vertical-align: text-bottom;
+	fill: currentColor;
+}
+
+.qs-run-legend svg {
+	width: 12px;
+	height: 12px;
+	flex: 0 0 12px;
+	fill: var(--qs-icon-success);
+}
+
+.qs-run-bar__progress {
+	display: flex;
+	width: min(32rem, 48vw);
+	height: 12px;
+	margin: 0;
+	background: #fff;
+}
+
+.qs-run-bar__progress .cdx-progress-bar__bar {
+	position: static;
+	height: 100%;
+	animation: none;
+}
+
+.qs-run-bar__progress .bg-success {
+	background: var(--qs-progressive) !important;
+}
+
+.qs-run-bar__waiting {
+	background: transparent !important;
+}
+
+.qs-command-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin: auto 0 8px;
+}
+
+.qs-command-toolbar .position_button_bar {
+	display: flex;
+}
+
+.qs-command-toolbar .btn-toolbar,
+.qs-command-toolbar__page,
+.qs-command-toolbar__filters {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.qs-command-toolbar__page input {
+	width: 5rem;
+}
+
+.qs-command-toolbar__filters {
+	margin-inline-start: auto;
+}
+
+.qs-command-filters {
+	display: flex;
+	width: fit-content;
+	margin-block-end: 4px;
+}
+
+.qs-command-toolbar__filters label {
+	margin: 0;
+}
+
+.qs-command-toolbar__size select {
+	min-width: 4.5rem;
+}
+
+@media (max-width: 767px) {
+	.qs-run-bar__actions {
+		width: 100%;
+		margin-inline-start: 0;
+		justify-content: flex-start;
+	}
+
+	.qs-command-toolbar__filters {
+		width: 100%;
+		margin-inline-start: 0;
+	}
+}
+
+.qs-message {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	border: 1px solid var(--qs-border);
+	border-radius: 2px;
+	background: #fff;
+	color: var(--qs-text);
+	direction: inherit;
+	text-align: start;
+}
+
+.qs-message--error {
+	border-color: #c8ccd1;
+	border-inline-start: 3px solid var(--qs-destructive);
+}
+
+.qs-message__icon {
+	display: inline-flex;
+	flex: 0 0 20px;
+	height: 20px;
+	align-items: center;
+	color: var(--qs-destructive);
+}
+
+.qs-message__icon svg {
+	fill: currentColor;
+}
+
+.qs-message__content {
+	flex: 1;
+	min-width: 0;
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+}
+
+.qs-import-message {
+	margin-top: 8px;
+}
+
+.qs-action-message {
+	margin-block: 8px;
+}
+
+.qs-import-help section {
+	scroll-margin-top: 16px;
+}
+
+.qs-import-help section + section {
+	margin-top: 24px;
+	padding-top: 24px;
+	border-top: 1px solid var(--qs-border-subtle);
+}
+
+.qs-import-help h3 {
+	margin: 0 0 8px;
+}
+
+.qs-import-help p {
+	margin: 0 0 10px;
+	line-height: var(--qs-line-height-medium);
+}
+
+.qs-command-example {
+	margin: 0 0 12px;
+	padding: 8px 12px;
+	overflow-x: auto;
+	border: 1px solid var(--qs-border-subtle);
+	border-radius: 2px;
+	background: #f8f9fa;
+}
+
+.qs-footer {
+	flex: 0 0 auto;
+	width: 100%;
+	max-width: 1200px;
+	margin: 0 auto;
+	padding: 0 16px 24px;
+	color: var(--qs-subtle);
+	font-size: var(--qs-font-size-small);
+	line-height: var(--qs-line-height-small);
+	text-align: start;
+}
+
+.qs-footer hr {
+	margin: 0 0 10px;
+	border-color: var(--qs-border-subtle);
+}
+
+.qs-footer-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px 16px;
+	margin: 0 0 4px;
+	padding: 0;
+	list-style: none;
+}
+
+.qs-footer p {
+	margin: 2px 0 0;
+}
+
+.qs-footer a {
+	color: var(--qs-progressive);
+}
+
+.qs-report-issues-short {
+	display: none;
+}
+
+.qs-mobile-new-batch__short {
+	display: none;
+}
+
+@media (max-width: 375px) {
+	.qs-import-actions__buttons {
+		display: flex;
+		gap: 8px;
+	}
+
+	.qs-import-actions__buttons .btn {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	.qs-mobile-new-batch__full {
+		display: none;
+	}
+
+	.qs-mobile-new-batch__short {
+		display: inline;
+	}
+}
+
+@media (max-width: 575px) {
+	.qs-report-issues-full {
+		display: none;
+	}
+
+	.qs-report-issues-short {
+		display: inline;
+	}
+
+	.qs-main {
+		padding-top: 16px;
+	}
+
+	.qs-login {
+		margin-top: 3vh;
+		padding: 22px 20px 24px;
+	}
+
+	.qs-manage-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.qs-intro-card {
+		align-items: flex-start;
+		flex-direction: column;
+		padding: 20px;
+	}
+
+	.qs-intro-card__action {
+		margin-inline-start: 0;
+	}
+
+	.qs-batch-setup {
+		align-items: stretch;
+		flex-direction: column;
+	}
+}

--- a/public_html/quickstatements.js
+++ b/public_html/quickstatements.js
@@ -12,6 +12,10 @@ var QuickStatements = {
 	run_state: { running: false },
 	batch_update_interval: 5000,
 
+	showNotice: function (message) {
+		$('#qs_old_notice').text(message).show();
+	},
+
 	init: function () {
 		var me = this;
 
@@ -291,7 +295,7 @@ var QuickStatements = {
 		}, function (d) {
 
 			if (d.status != 'OK') {
-				alert(d.status);
+				me.showNotice(d.status);
 				console.log(d);
 				return;
 			}
@@ -316,7 +320,6 @@ var QuickStatements = {
 		if (typeof me.run_state.batch_watcher != 'undefined') clearInterval(me.run_state.batch_watcher);
 		if (in_background) {
 			me.runInBackground();
-			//			alert ( "Not implemented yet" ) ;
 			return;
 		}
 		me.run_state = {
@@ -346,7 +349,6 @@ var QuickStatements = {
 		$('#run_buttons button').prop('disabled', true);
 		$('#stop_buttons').show();
 		if (in_background) {
-			//			alert ( "Not implemented yet" ) ;
 		} else {
 			me.runNextCommand();
 		}

--- a/public_html/quickstatements.php
+++ b/public_html/quickstatements.php
@@ -1363,7 +1363,7 @@ class QuickStatements {
 			$to_load = [ $q ] ;
 			if ( isset($command->property) and $this->isProperty($command->property) ) $to_load[] = $command->property ;
 			$this->wd->loadItems ( $to_load ) ;
-			if ( !$this->wd->hasItem($q) ) return $this->commandError ( $command , "Item $q is not available" ) ;
+			if ( !$this->wd->hasItem($q) ) return $this->commandError ( $command , "Could not load item $q" ) ;
 			$i = $this->wd->getItem ( $q ) ;
 
 			if ( $command->action == 'add' ) {

--- a/public_html/vue-component-loader.js
+++ b/public_html/vue-component-loader.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// Component template loader kept with QuickStatements so application startup
+// does not depend on the shared Toolforge asset host being available.
+let vue_components = {
+	toolname: window.location.pathname.replace(/(\/|\.php|\.html{0,1})+$/, '').replace(/^.*\//, ''),
+	components: {},
+	template_container_base_id: 'vue_component_templates',
+	components_base_url: 'https://tools-static.wmflabs.org/magnustools/resources/vue/',
+	serial_loading: false,
+	fetch_timeout_ms: 0,
+	fetch_retries: 0,
+	loadComponents: function (components) {
+		if (this.serial_loading) {
+			return components.reduce((chain, component) => chain
+				.then(() => this.fetchComponent(component))
+				.then(html => this.injectComponent(component, html)), Promise.resolve());
+		}
+		return Promise.all(components.map(component => this.fetchComponent(component)))
+			.then(fetched => fetched.map((html, i) => this.injectComponent(components[i], html)));
+	},
+	getComponentID: function (component) {
+		if (typeof this.components[component] != 'undefined') return this.components[component];
+		this.components[component] = this.template_container_base_id + '-' + Object.keys(this.components).length;
+		return this.components[component];
+	},
+	getComponentURL: function (component) {
+		return /^(http:|https:|\/|\.)/.test(component) || /\.html$/.test(component)
+			? component
+			: this.components_base_url + component + '.html';
+	},
+	loadComponent: function (component) {
+		return this.fetchComponent(component).then(html => this.injectComponent(component, html));
+	},
+	fetchComponent: function (component) {
+		let id = this.getComponentID(component);
+		if ($('#' + id).length > 0) return Promise.resolve();
+		let component_url = this.getComponentURL(component);
+		return this.fetchComponentURL(component_url, this.fetch_retries);
+	},
+	fetchComponentURL: function (component_url, retries_left) {
+		let controller = this.fetch_timeout_ms > 0 ? new AbortController() : null;
+		let timeout = controller ? setTimeout(() => controller.abort(), this.fetch_timeout_ms) : null;
+		return fetch(component_url, {
+			cache: 'no-store',
+			signal: controller ? controller.signal : undefined
+		}).then(response => {
+			if (!response.ok) throw new Error('Could not load component: ' + component_url);
+			return response.text();
+		}).finally(() => {
+			if (timeout) clearTimeout(timeout);
+		}).catch(error => {
+			if (retries_left > 0) {
+				console.warn('Retrying component after a loading failure:', component_url, error);
+				return this.fetchComponentURL(component_url, retries_left - 1);
+			}
+			throw error;
+		});
+	},
+	injectComponent: function (component, html) {
+		if (!html) return;
+		let id = this.getComponentID(component);
+		$('body').append($('<div>').attr({id: id}).css({display: 'none'}).html(html));
+	}
+};

--- a/public_html/vue.js
+++ b/public_html/vue.js
@@ -8,11 +8,48 @@ let config = {} ;
 let prop_map = {} ;
 let working = false ;
 
+function syncDocumentDirection (selectedLanguage) {
+	const rtlLanguages = [
+		'ar', 'arc', 'arz', 'ks', 'lrc', 'mzn', 'azb', 'nqo', 'pnb',
+		'ps', 'sd', 'ug', 'ur', 'yi', 'ckb', 'dv', 'fa', 'glk', 'he'
+	] ;
+	const cookieLanguage = document.cookie.match(/(?:^|;\s*)interface_language=([^;]+)/) ;
+	const toolLanguage = typeof tt != 'undefined' && tt && tt.language ? tt.language : '' ;
+	const savedLanguage = cookieLanguage ? decodeURIComponent(cookieLanguage[1]) : '' ;
+	const language = (selectedLanguage || toolLanguage || savedLanguage || document.documentElement.lang || 'en').replace(/-.+$/, '') ;
+	const direction = rtlLanguages.indexOf(language) > -1 ? 'rtl' : 'ltr' ;
+	document.documentElement.setAttribute('lang', language) ;
+	document.documentElement.setAttribute('dir', direction) ;
+	document.body.setAttribute('dir', direction) ;
+	document.body.style.direction = direction ;
+}
+
 $(document).ready ( function () {
+	const workingElement = document.getElementById('working') ;
+	if (workingElement) {
+		const syncWorkingState = function () {
+			document.body.classList.toggle('qs-is-working', window.getComputedStyle(workingElement).display != 'none') ;
+		} ;
+		new MutationObserver(syncWorkingState).observe(workingElement, {attributes:true,attributeFilter:['class','style']}) ;
+		syncWorkingState() ;
+	}
+	syncDocumentDirection () ;
+	$(document).on('change.qsDirection', '#tooltranslate_wrapper select', function () {
+		syncDocumentDirection(this.value) ;
+	}) ;
     vue_components.toolname = 'quickstatements' ;
+	// XAMPP serves the magnustools checkout beside QuickStatements. Use those
+	// templates for private-network previews, where tools-static may be blocked.
+	if ( /^(localhost|127\.0\.0\.1|::1|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(location.hostname) ) {
+		vue_components.components_base_url = '../../magnustools/public_html/resources/vue/' ;
+		vue_components.serial_loading = true ;
+		vue_components.fetch_timeout_ms = 5000 ;
+		vue_components.fetch_retries = 2 ;
+	}
+    $.ajaxSetup ( { cache:false } ) ;
 //    vue_components.components_base_url = 'https://tools.wmflabs.org/magnustools/resources/vue/' ; // For testing; turn off to use tools-static
     Promise.all ( [
-            vue_components.loadComponents ( ['wd-date','wd-link','tool-translate','tool-navbar','commons-thumbnail',
+            vue_components.loadComponents ( ['wd-date','wd-link','tool-translate','commons-thumbnail',
                 'vue_components/batch_access_mixin.html',
                 'vue_components/user.html',
                 'vue_components/main-page.html',
@@ -29,6 +66,8 @@ $(document).ready ( function () {
                 } , 'json' ) ;
             } )
     ] ) .then ( () => {
+		syncDocumentDirection () ;
+        $.ajaxSetup ( { cache:true } ) ;
         const siteConfig = config.sites[config.site] ;
         const apiUrl = siteConfig.publicApi || siteConfig.api ;
         wd_link_base = siteConfig.pageBase ;
@@ -50,7 +89,19 @@ $(document).ready ( function () {
           { path: '/:url_params', component: MainPage , props:true },
         ] ;
         router = new VueRouter({routes}) ;
-        app = new Vue ( { router } ) .$mount('#app') ;
-    } ) ;
+        app = new Vue ( {
+            router,
+            data : {
+                authLoaded : false,
+                isLoggedIn : false,
+                userinfo : {}
+            }
+        } ) .$mount('#app') ;
+    } ) .catch ( error => {
+		console.error(error) ;
+		document.getElementById('app').removeAttribute('v-cloak') ;
+		document.querySelector('.qs-loading').style.display = 'none' ;
+		document.getElementById('qs-startup-error').hidden = false ;
+	} ) ;
 } ) ;
 

--- a/public_html/vue_components/batch-commands.html
+++ b/public_html/vue_components/batch-commands.html
@@ -9,49 +9,42 @@ div.position_button_bar > div {
 </style>
 
 <template id='batch-commands-template'>
-<div>
-<div v-if='typeof batch!="undefined" && typeof batch.data!="undefined" && typeof batch.data.commands!="undefined"'>
+<div class='qs-command-list'>
+	<div v-if='typeof batch!="undefined"' class='qs-command-filters qs-radio-buttons' role='radiogroup' aria-label='Command status'>
+		<label><input type='radio' v-model='view.filter' value='' @change='onFilterChange'><span>All</span></label>
+		<label><input type='radio' v-model='view.filter' value='INIT' @change='onFilterChange'><span>Open</span></label>
+		<label><input type='radio' v-model='view.filter' value='UNCHANGED' @change='onFilterChange'><span>Unchanged</span></label>
+		<label><input type='radio' v-model='view.filter' value='ERROR' @change='onFilterChange'><span>Errors</span></label>
+	</div>
+	<div class='qs-batch-commands-panel qs-command-list-shell'>
+	<div v-if='typeof batch!="undefined" && typeof batch.data!="undefined" && typeof batch.data.commands!="undefined"' class='qs-command-list-content'>
 	<div style='display:flex;flex-direction:column;'>
 		<command v-for='command_id in current_command_ids' :command='batch.data.commands[command_id]' :site='batch.site||""'></command>
 	</div>
-	<div style='display:flex;'>
+	<div v-if='showPagingControls' class='qs-command-toolbar'>
 		<div class='position_button_bar'>
-			<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-				<div class="btn-group mr-2" role="group">
-					<button type="button" class="btn btn-outline-secondary" v-if='view.position>0' @click.prevent='setViewPosition(0)' tt='bc_start'></button>
-					<button type="button" class="btn btn-outline-secondary" disabled v-else tt='bc_start'></button>
-					<button type="button" class="btn btn-outline-secondary" v-if='view.position>0 && view.filter==""' @click.prevent='setViewPosition(view.position-view.batch_size)'  tt='bc_previous'></button>
+			<div class='btn-toolbar' role='toolbar' aria-label='Command pages'>
+				<div class='btn-group' role='group'>
+					<button type='button' class='btn btn-outline-secondary' :disabled='view.position<=0' @click.prevent='setViewPosition(0)' tt='bc_start'></button>
+					<button type='button' class='btn btn-outline-secondary' :disabled='view.position<=0 || view.filter!=""' @click.prevent='setViewPosition(view.position-view.batch_size)' tt='bc_previous'></button>
 				</div>
-				<div class="btn-group mr-1" role="group">
-					<span tt='page' style='margin-top:0.4rem;margin-right:0.2rem;'></span>
-					<input v-model='view.wanted_page' @keyup='onChangeWantedPage' class='form-control' type='number' style='width:5rem;' />
+				<div class='btn-group qs-command-toolbar__page' role='group'>
+					<label for='qs-command-page' tt='page'></label>
+					<input id='qs-command-page' v-model='view.wanted_page' @keyup='onChangeWantedPage' class='form-control' type='number' />
 				</div>
-				<div class="btn-group mr-2" role="group">
-					<button type="button" class="btn btn-outline-secondary" v-if='current_command_ids.length==view.batch_size' @click.prevent='setViewPosition(current_command_ids[view.batch_size-1]+1)' tt='bc_next'></button>
-					<button type="button" class="btn btn-outline-secondary" v-if='current_command_ids.length==view.batch_size' @click.prevent='setViewPosition(batch.total_commands-view.batch_size)' tt='bc_end'></button>
-					<button type="button" class="btn btn-outline-secondary" disabled v-else tt='bc_end'></button>
+				<div class='btn-group' role='group'>
+					<button type='button' class='btn btn-outline-secondary' :disabled='!canGoForward' @click.prevent='setViewPosition(current_command_ids[current_command_ids.length-1]+1)' tt='bc_next'></button>
+					<button type='button' class='btn btn-outline-secondary' :disabled='!canGoToEnd' @click.prevent='setViewPosition(lastPagePosition)' tt='bc_end'></button>
 				</div>
 			</div>
 		</div>
-		<div style='display:flex;flex-grow:1;'>
-		</div>
-		<div style='display:inherit'>
-			<div style='margin-top:0.3rem;margin-right:0.2rem'>
-				<label><input type='radio' v-model='view.filter' value='' @change='onFilterChange'> All</label>
-				<label><input type='radio' v-model='view.filter' value='ERROR' @change='onFilterChange'> <span tt='errors'></span></label>
-				<label><input type='radio' v-model='view.filter' value='INIT' @change='onFilterChange'> Init</label>
-			</div>
-		</div>
-		<div style='display:inherit'>
+		<div v-if='showPagingControls' class='qs-command-toolbar__size'>
 			<select class='form-control' v-model='view.batch_size' @change='setCurrentViewCommandIDs'>
-				<option value='10'>10</option>
-				<option value='25'>25</option>
-				<option value='50'>50</option>
-				<option value='100'>100</option>
-				<option value='500'>500</option>
+				<option value='25'>25</option><option value='50'>50</option><option value='100'>100</option><option value='500'>500</option>
 			</select>
 		</div>
 	</div>
+</div>
 </div>
 </div>
 </template>
@@ -62,17 +55,32 @@ div.position_button_bar > div {
 Vue.component ( 'batch-commands' , {
 	props : [ 'batch' ] ,
 	mixins : [ batch_helper_mixin ] ,
-	data : function () { return { current_command_ids:[] , view:{is_loaded:false,load_partially:false,position:0,batch_size:10,filter:'',wanted_page:1} , status:[] , working:false } } ,
+	data : function () { return { current_command_ids:[] , view:{is_loaded:false,load_partially:false,position:0,batch_size:25,filter:'',wanted_page:1} , status:[] , working:false } } ,
     created : function () {} ,
     updated : function () { tt.updateInterface(this.$el) ; } ,
     mounted : function () {
     	var me = this ;
     	me.reset() ;
     	if ( me.batch.id > 0 ) me.view.load_partially = true ;
-    	me.setCurrentViewCommandIDs() ;
-    	tt.updateInterface(this.$el) ;
-    } ,
-    methods : {
+		me.setCurrentViewCommandIDs() ;
+		tt.updateInterface(this.$el) ;
+	} ,
+	computed : {
+		showPagingControls : function () {
+			return this.view.position > 0 || (this.batch.total_commands || 0) > 10 ;
+		},
+		lastPagePosition : function () {
+			return Math.max(0, Number(this.batch.total_commands || 0) - Number(this.view.batch_size)) ;
+		},
+		canGoForward : function () {
+			if (this.current_command_ids.length < Number(this.view.batch_size)) return false ;
+			return Number(this.current_command_ids[this.current_command_ids.length - 1]) < Number(this.batch.total_commands || 0) - 1 ;
+		},
+		canGoToEnd : function () {
+			return Number(this.view.position) < this.lastPagePosition ;
+		}
+	} ,
+	methods : {
     	reset : function () {
     		var me = this ;
     		me.view.wanted_page = 1 ;
@@ -150,8 +158,13 @@ Vue.component ( 'batch-commands' , {
 			let me = this ;
 			if ( me.view.filter == '' ) return true ;
 			if ( typeof me.batch.data.commands[command_id] == 'undefined' ) return false ;
+			if ( me.view.filter == 'UNCHANGED' ) return me.isUnchangedCommand ( me.batch.data.commands[command_id] ) ;
 			if ( me.batch.data.commands[command_id].meta.status == me.view.filter ) return true ;
 			return false ;
+		} ,
+		isUnchangedCommand : function ( command ) {
+			if ( !command.meta || (command.meta.status || '').toUpperCase() != 'DONE' ) return false ;
+			return /already exists|already has|has already a qualifier/i.test(command.meta.message || '') ;
 		} ,
 		onFilterChange : function () {
 			this.view.position = 0 ;

--- a/public_html/vue_components/batch.html
+++ b/public_html/vue_components/batch.html
@@ -4,7 +4,8 @@
 	}
 
 	div.batch_status_header>div {
-		font-size: 14pt;
+		font-size: var(--qs-font-size-large);
+		line-height: var(--qs-line-height-large);
 		padding: 3px;
 	}
 
@@ -18,13 +19,11 @@
 		<div v-if='ready'>
 
 			<div>
-				<div v-if='batch_exists'>
+				<div v-if='batch_exists' class='qs-batch-view'>
 					<div class='batch_status_header'>
 						<div>
-							<span tt='batch'></span>
-							<span v-if='meta.batch.id!=0'>
-								#{{meta.batch.id}}
-							</span>
+							<span v-if='meta.batch.id==0'>New batch</span>
+							<span v-else><span tt='batch'></span> #{{meta.batch.id}}</span>
 						</div>
 						<div v-if='typeof meta.batch.name!="undefined" && meta.batch.name!=""'>
 							"<tt>{{meta.batch.name}}</tt>"
@@ -32,130 +31,112 @@
 						<div>
 							<span tt='on'></span> {{config.sites[meta.batch.site].label}}
 						</div>
-						<div>
-							<span tt='by'></span>
-							<a :href="config.sites[config.site].pageBase + 'User:'+encodeURIComponent(meta.batch.user_name)"
-								target='_blank' class='wikidata'>
-								{{meta.batch.user_name.replace(/_/g,' ')}}
-							</a>
-							[<router-link :to='"/batches/"+meta.batch.user_name' tt='batches'></router-link>]
-						</div>
-						<div v-if='(meta.commands.DONE||0)>0'>
-							<span v-if='meta.batch.id==0'>
-								<a target='_blank' class='external'
-									:href='"https://editgroups.toolforge.org/b/QSv2T/"+encodeURIComponent(run.temp_id.replace(/\D/g,""))'
-									tt='revert_batch'></a>
-							</span>
-							<span v-else>
-								<a target='_blank' class='external'
-									:href='"https://editgroups.toolforge.org/b/QSv2/"+meta.batch.id'
-									tt='revert_batch'></a>
-							</span>
-						</div>
 						<div style='flex-grow:1'></div>
 					</div>
-					<div class='batch_status_header'>
-						<div>
-							<span tt='status'></span>: {{meta.batch.status}}
-						</div>
-						<div style='flex-grow:1;'>
-							<div class="progress" style='height:21pt'>
-								<div class="progress-bar bg-success" role="progressbar"
-									:style="'width:'+((meta.commands.DONE||0)*100/meta.batch.total_commands)+'%'"
-									tt_title='done'></div>
-								<div class="progress-bar bg-danger" role="progressbar"
-									:style="'width:'+((meta.commands.ERROR||0)*100/meta.batch.total_commands)+'%'"
-									tt_title='error'></div>
-								<div class="progress-bar" role="progressbar"
-									:style="'width:'+((meta.batch.total_commands-(meta.commands.DONE||0)-(meta.commands.RUN||0)-(meta.commands.ERROR||0))*100/meta.batch.total_commands)+'%'"
-									tt_title='waiting'></div>
-							</div>
-						</div>
-						<div>
-							{{Number((100*((meta.commands.DONE||0)*1+(meta.commands.ERROR||0)*1)/meta.batch.total_commands).toFixed(1))}}%
-							({{Number((meta.commands.DONE||0)*1+(meta.commands.RUN||0)*1).toFixed(0)}})
-							<span tt='of'></span> {{meta.batch.total_commands}} <span tt='done'></span>
-						</div>
-						<div v-if='(meta.commands.ERROR||0)>0'>, {{(meta.commands.ERROR||0)}} <span tt='errors'></span>
-						</div>
+					<div v-if='action_error' class='qs-message qs-message--error qs-action-message' role='alert'>
+						<span class='qs-message__icon' aria-hidden='true'><svg class='cdx-icon cdx-icon--bidi-neutral' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><path d='M19.765 16.059 18 19H2L.235 16.059l8-15h3.53zM9 14v2h2v-2zm0-8v6h2V6z'></path></svg></span>
+						<span class='qs-message__content'><bdi dir='auto'>{{action_error}}</bdi></span>
 					</div>
-					<div style='margin-top:0.5rem;padding-top:0.5rem;border-top:2px solid #DDD'>
+					<div class='qs-command-section'>
 						<batch-commands :batch='meta.batch' @load-command='loadCommand($event)'></batch-commands>
 					</div>
-					<div style='display:flex;flex-direction:row;margin-bottom:0.5rem;'>
-						<div v-if='meta.batch.status=="RUN" || meta.batch.status=="INIT"'>
-							<button v-if='userCanStopBatch()' class='btn btn-outline-danger'
-								@click='stopBatch'>STOP</button>
-							<span v-else>
-								<span tt='original_submitter_hint'></span>
-								<span v-if='!user.is_logged_in'>
-									<span tt='admin_hint'></span> <a href='./api.php?action=oauth_redirect'><span
-											tt='login'></span></a>!
+					<div class='qs-run-bar'>
+						<div class='qs-run-bar__status'>
+							<span v-if='!runHasStarted'>{{meta.batch.total_commands}} command<span v-if='meta.batch.total_commands!=1'>s</span> ready</span>
+							<div v-else class='qs-run-bar__progress-wrap'>
+								<span class='qs-run-status'>
+									<span tt='status'></span>:
+									<template v-if='meta.batch.status=="DONE"'>
+										<svg class='qs-run-status__icon' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' aria-hidden='true'><path d='M10 1a9 9 0 110 18 9 9 0 010-18M8.823 11.118 6.8 9.6l-1.2 1.6 2.8 2.1 1.381-.175 4.624-5.781-1.561-1.25z'></path></svg>
+										<span>Done</span>
+									</template>
+									<span v-else>{{meta.batch.status}}</span>
 								</span>
-							</span>
+								<div class='cdx-progress-bar cdx-progress-bar--block cdx-progress-bar--determinate qs-run-bar__progress' role='progressbar' aria-label='Batch progress' :aria-valuenow='runProgressPercent' aria-valuemin='0' aria-valuemax='100'>
+									<div class='cdx-progress-bar__bar bg-success' :style="'width:'+runDonePercent+'%'" tt_title='done'></div>
+									<div class='cdx-progress-bar__bar bg-danger' :style="'width:'+runErrorPercent+'%'" tt_title='error'></div>
+									<div class='cdx-progress-bar__bar qs-run-bar__waiting' :style="'width:'+runWaitingPercent+'%'" tt_title='waiting'></div>
+								</div>
+								<small>{{runCompletedCount}} / {{meta.batch.total_commands}}<span v-if='(meta.commands.ERROR||0)>0'> ({{meta.commands.ERROR}} <span tt='errors'></span>)</span></small>
+								<div class='qs-run-legend'>
+									<svg viewBox='0 0 20 20' aria-hidden='true'><path d='M9.3572.5208c.194-.6944 1.0916-.6944 1.2856 0l1.325 4.7424c.1032.3696.4499.5888.7938.502l4.4123-1.1145c.6461-.1632 1.0949.6882.6428 1.2194l-3.0873 3.6279a.77.77 0 0 0 0 1.004l3.0873 3.6279c.4521.5312.0033 1.3826-.6428 1.2194l-4.4123-1.1144c-.3439-.0869-.6906.1323-.7938.502l-1.325 4.7423c-.194.6944-1.0916.6944-1.2856 0l-1.325-4.7423c-.1032-.3697-.4499-.5889-.7938-.502l-4.4123 1.1144c-.6461.1632-1.0949-.6882-.6428-1.2194l3.0873-3.6279a.77.77 0 0 0 0-1.004L2.1833 5.8701c-.4521-.5312-.0033-1.3826.6428-1.2194l4.4123 1.1145c.3439.0868.6906-.1324.7938-.502z'/></svg>
+									<span>An asterisk means the command succeeded, but no change was needed because the value was already present.</span>
+								</div>
+								<div v-if='meta.batch.status=="DONE" && (meta.commands.DONE||0)>0' class='qs-run-followup'>
+									<span>You can </span><a target='_blank' rel='noopener' class='qs-external-action'
+										:href='meta.batch.id==0 ? "https://editgroups.toolforge.org/b/QSv2T/"+encodeURIComponent(run.temp_id.replace(/\D/g,"")) : "https://editgroups.toolforge.org/b/QSv2/"+meta.batch.id'><span>revert or discuss this batch</span><svg class='cdx-icon cdx-icon--flip-for-rtl' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' aria-hidden='true'><path d='M8 7H3v10h10v-5h2v7H1V5h7z'></path><path d='M19.001 2 19 8h-2V4.415l-9 9L6.586 12l9-8.999L12 3V1h6.001z'></path></svg></a>.
+								</div>
+							</div>
 						</div>
-						<div v-else>
-							<span v-if='user.canRunBatch()'>
-								<button v-if='(meta.commands.INIT||0)>0 && meta.batch.id==0'
-									class='btn btn-outline-primary' tt='run' @click='runBatchDirectly'></button>
-								<button v-if='(meta.commands.ERROR||0)>0 && meta.batch.status=="DONE"'
-									class='btn btn-outline-success' @click='tryResetErrors'>Try to reset errors</button>
-							</span>
-							<span
-								v-if='user.canSubmitBatch() && !run.is_running_in_browser && (meta.commands.INIT||0)>0'>
-								<button v-if='' class='btn btn-outline-primary' tt='run_background'
-									@click='runBatchInBackground'></button>
-							</span>
+						<div class='qs-run-bar__actions'>
+							<template v-if='(meta.commands.INIT||0)>0 && meta.batch.status!="RUN"'>
+								<button key='run-batch' v-if='user.canRunBatch() && (meta.commands.INIT||0)>0 && meta.batch.id==0' class='btn btn-primary' tt='run' @click='runBatchDirectly'></button>
+								<button key='run-batch-background' v-if='user.canSubmitBatch() && (meta.commands.INIT||0)>0' class='btn btn-outline-primary' tt='run_background' @click='runBatchInBackground'></button>
+							</template>
+							<button v-if='(meta.commands.ERROR||0)>0 && meta.batch.status=="DONE"' class='btn btn-outline-primary' @click='tryResetErrors'>Try to reset errors</button>
+							<button key='stop-batch' v-if='(meta.batch.status=="RUN" || meta.batch.status=="INIT") && userCanStopBatch()' class='btn btn-danger' @click='stopBatch'>STOP</button>
 						</div>
 					</div>
 				</div>
 				<div v-else-if='user.canCreateBatch()' class='create_batch_box'>
-					<form class='form-inline'>
-						<span tt='create_new_batch'></span>
-						<select class='form-control' v-model='meta.batch.site'
-							style='margin-left:10px;margin-right:10px'>
-							<option v-for='(sd,sid) in config.sites' :value='sid'>
-								{{sd.label}}
-							</option>
-						</select>
-						<span tt='as'></span>
-						<input type='text' class='form-control' v-model='meta.batch.name' style='margin-left:10px'
-							tt_placeholder='ph_batch_name' />
+					<form class='qs-new-batch-form' @submit.prevent='importV1'>
+					<div class='qs-batch-setup'>
+						<fieldset class='qs-batch-project'>
+							<legend>Project</legend>
+							<div class='qs-radio-buttons'>
+								<label>
+									<input type='radio' value='wikidata' v-model='meta.batch.site' />
+									<span>Wikidata</span>
+								</label>
+								<label>
+									<input type='radio' value='commons' v-model='meta.batch.site' />
+									<span>Wikimedia Commons</span>
+								</label>
+							</div>
+						</fieldset>
+						<div class='qs-batch-name'>
+							<label for='qs-batch-name'>Batch name</label>
+							<input id='qs-batch-name' type='text' class='form-control' v-model.trim='meta.batch.name'
+								@keydown.enter.prevent='importV1' />
+						</div>
+					</div>
+
+					<div class='qs-command-editor'>
+						<label for='qs-command-editor'>Commands</label>
+						<textarea id='qs-command-editor' v-model='commands' rows=15 class='form-control' dir='ltr'
+							style='width:100%;'></textarea>
+					</div>
+					<div class='qs-import-actions'>
+						<div class='qs-import-actions__buttons'>
+							<button type='submit' class='btn btn-outline-primary' :disabled='importing'>Import commands</button>
+							<button type='button' class='btn btn-outline-primary' @click='importCSV' :disabled='importing'>Import CSV</button>
+						</div>
+						<div v-if='importing' class='cdx-progress-bar cdx-progress-bar--inline qs-import-progress' role='progressbar'
+							aria-label='Importing commands' aria-busy='true'><div class='cdx-progress-bar__bar'></div></div>
+						<div v-if='import_error' class='qs-message qs-message--error qs-import-message' role='alert'>
+							<span class='qs-message__icon' aria-hidden='true'>
+								<svg class='cdx-icon cdx-icon--bidi-neutral' xmlns='http://www.w3.org/2000/svg'
+									width='20' height='20' viewBox='0 0 20 20'><path d='M19.765 16.059 18 19H2L.235 16.059l8-15h3.53zM9 14v2h2v-2zm0-8v6h2V6z'></path></svg>
+							</span>
+							<span class='qs-message__content'><bdi dir='auto'>{{import_error}}</bdi></span>
+						</div>
+					</div>
 					</form>
 
-					<div>
-						<textarea v-model='commands' rows=15 class='form-control'
-							style='width:100%;font-family:monospace;'></textarea>
-					</div>
-					<div>
-						<button class='btn btn-outline-primary' @click.prevent='importV1'
-							tt='dialog_import_v1'></button>
-						<button class='btn btn-outline-primary' @click.prevent='importCSV'
-							tt='dialog_import_csv'></button>
-					</div>
-
 					<hr />
-					<div class="row">
-						<div class="col-2">
-							<div class="list-group" id="list-tab" role="tablist">
-								<a class="list-group-item list-group-item-action active" id="list-home-list"
-									data-toggle="list" href="#help-v1" role="tab" tt='dialog_import_v1'></a>
-								<a class="list-group-item list-group-item-action" id="list-profile-list"
-									data-toggle="list" href="#help-csv" role="tab" tt='dialog_import_csv'></a>
-							</div>
-						</div>
-						<div class="col-10">
-							<div class="tab-content" id="nav-tabContent">
-								<div class="tab-pane fade show active" id="help-v1" role="tabpanel">
-									<h3 tt='dialog_import_v1'></h3>
-									<div tt='dialog_import_v1_intro'></div>
-								</div>
-								<div class="tab-pane fade" id="help-csv" role="tabpanel">
-									<h3 tt='dialog_import_csv'></h3>
-									<div tt='dialog_import_csv_intro'></div>
-								</div>
-							</div>
-						</div>
+					<div class="qs-import-help">
+						<section id="help-v1" aria-labelledby="help-v1-title">
+							<h3 id="help-v1-title">Import commands</h3>
+							<p>Commands are short instructions that tell QuickStatements what structured data to add or remove from Wikidata or Wikimedia Commons.</p>
+							<p>Put one command on each line in the editor above.</p>
+							<p>For example, this command says that Douglas Adams is a human:</p>
+							<pre class="qs-command-example" dir="ltr"><code>Q42	P31	Q5</code></pre>
+							<p>See <a href="https://www.wikidata.org/wiki/Help:QuickStatements" target="_blank" rel="noopener">Help:QuickStatements</a> for the complete syntax and more examples.</p>
+						</section>
+						<section id="help-csv" aria-labelledby="help-csv-title">
+							<h3 id="help-csv-title">Import CSV</h3>
+							<p>See <a href="https://www.wikidata.org/wiki/Help:QuickStatements#CSV_file_syntax" target="_blank" rel="noopener">CSV file syntax on Help:QuickStatements</a> for the column format and examples.</p>
+						</section>
 					</div>
 
 				</div>
@@ -178,7 +159,7 @@
 	let BatchPage = Vue.extend({
 		props: ['batch'],
 		mixins: [batch_access_mixin],
-		data: function () {return {api: './api.php', ready: false, commands: '', run: {is_running_in_browser: false, last_item: '', last_form: '', last_sense: '', temp_id: '', start_ts: '', last_ts: ''}, direct_command_delay_ms: 1}},
+		data: function () {return {api: './api.php', ready: false, commands: '', importing: false, import_error: '', action_error: '', run: {is_running_in_browser: false, last_item: '', last_form: '', last_sense: '', temp_id: '', start_ts: '', last_ts: ''}, direct_command_delay_ms: 1}},
 		created: function () {
 			var me = this;
 
@@ -210,6 +191,27 @@
 		},
 		updated: function () {tt.updateInterface(this.$el);},
 		mounted: function () {tt.updateInterface(this.$el);},
+		computed: {
+			runHasStarted: function () {
+				return this.meta.batch.id > 0 || ['RUN', 'DONE', 'STOP'].indexOf(this.meta.batch.status) > -1 ||
+					((this.meta.commands.DONE || 0) + (this.meta.commands.ERROR || 0) + (this.meta.commands.RUN || 0)) > 0;
+			},
+			runCompletedCount: function () {
+				return (this.meta.commands.DONE || 0) * 1 + (this.meta.commands.ERROR || 0) * 1;
+			},
+			runProgressPercent: function () {
+				return this.meta.batch.total_commands ? 100 * this.runCompletedCount / this.meta.batch.total_commands : 0;
+			},
+			runDonePercent: function () {
+				return this.meta.batch.total_commands ? 100 * (this.meta.commands.DONE || 0) / this.meta.batch.total_commands : 0;
+			},
+			runErrorPercent: function () {
+				return this.meta.batch.total_commands ? 100 * (this.meta.commands.ERROR || 0) / this.meta.batch.total_commands : 0;
+			},
+			runWaitingPercent: function () {
+				return Math.max(0, 100 - this.runDonePercent - this.runErrorPercent);
+			}
+		},
 		methods: {
 			updateWDforSite: function () {
 				var me = this;
@@ -238,7 +240,7 @@
 			processParsedCommands: function (d) {
 				var me = this;
 				if (d.status != 'OK') {
-					alert("processParsedCommands: " + d.status);
+					me.import_error = 'The commands could not be imported: ' + d.status;
 					return;
 				}
 				$.each(d.data.commands, function (k, v) {
@@ -256,39 +258,60 @@
 				me.updateWDforSite();
 			},
 			importV1: function () {
-				var me = this;
-				$('#working').show();
-				$.post(me.api, {
-					action: 'import',
-					data: me.commands,
-					compress: 1,
-					format: 'v1',
-					persistent: 0,
-				}, function (d) {
-					$('#working').hide();
-					if (d.data.commands.length == 0) {
-						alert("No valid commands found");
-						return;
-					}
-					me.processParsedCommands(d);
-				}, 'json');
+				this.importCommands('v1', {compress: 1});
 			},
 			importCSV: function () {
+				this.importCommands('csv');
+			},
+			importCommands: function (format, extraData) {
 				var me = this;
-				$('#working').show();
-				$.post(me.api, {
+				if (me.importing) return;
+				me.import_error = '';
+				me.importing = true;
+				let requestData = Object.assign({
 					action: 'import',
 					data: me.commands,
-					format: 'csv',
+					format: format,
 					persistent: 0,
-				}, function (d) {
-					$('#working').hide();
-					if (d.data.commands.length == 0) {
-						alert("No valid commands found");
+				}, extraData || {});
+				let requestBody = new URLSearchParams();
+				Object.keys(requestData).forEach(function (key) {
+					requestBody.append(key, requestData[key]);
+				});
+				let encodedRequest = requestBody.toString();
+				let readImportResponse = function (response) {
+					if (!response.ok) throw new Error('Import request returned HTTP ' + response.status);
+					return response.json();
+				};
+				fetch(me.api, {
+					method: 'POST',
+					headers: {'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+					body: encodedRequest,
+					credentials: 'same-origin'
+				})
+				.then(readImportResponse)
+				.catch(function (postError) {
+					if (encodedRequest.length > 6000) throw postError;
+					console.warn('Import POST failed; retrying the short request with GET.', postError);
+					return fetch(me.api + '?' + encodedRequest, {
+						credentials: 'same-origin',
+						cache: 'no-store'
+					}).then(readImportResponse);
+				})
+				.then(function (d) {
+					if (!d.data || !d.data.commands || d.data.commands.length == 0) {
+						me.import_error = "No valid commands were found.";
 						return;
 					}
 					me.processParsedCommands(d);
-				}, 'json');
+				})
+				.catch(function (error) {
+					console.error(error);
+					me.import_error = "The commands could not be imported. Please try again.";
+				})
+				.finally(function () {
+					me.importing = false;
+				});
 			},
 			loadCommand: function (v) {
 				Vue.set(this.meta.batch.data.commands, v.num * 1, v.json);
@@ -318,6 +341,7 @@
 			},
 			tryResetErrors: function () {
 				var me = this;
+				me.action_error = '';
 				if (me.meta.batch.id == 0) { // In browser
 					$.each(me.meta.batch.data.commands, function (k, cmd) {
 						if (typeof cmd.meta == 'undefined' || typeof cmd.meta.status == 'undefined' || (cmd.meta.status != 'ERROR' && cmd.meta.status != 'RUN')) return;
@@ -336,12 +360,12 @@
 					}, function (d) {
 						$('#working').hide();
 						if (d.status != 'OK') {
-							alert(d.status);
+							me.action_error = 'The failed commands could not be reset: ' + d.status;
 							console.log(d);
 							return;
 						}
 						if (d.init == 0) {
-							alert("No failed commands could be reset");
+							me.action_error = 'No failed commands could be reset.';
 							return;
 						}
 						me.meta.batch.data.commands = [];
@@ -386,6 +410,12 @@
 				$('#working').show();
 				me.actuallyRunCommand(j, original_summary, cmdnum, 5);
 			},
+			markCommandFailed: function (cmdnum, message) {
+				Vue.set(this.meta.batch.data.commands[cmdnum].meta, 'message', message || 'The command request failed.');
+				Vue.set(this.meta.commands, 'RUN', Math.max(0, (this.meta.commands.RUN || 0) - 1));
+				Vue.set(this.meta.batch.data.commands[cmdnum].meta, 'status', 'ERROR');
+				Vue.set(this.meta.commands, 'ERROR', (this.meta.commands.ERROR || 0) + 1);
+			},
 			actuallyRunCommand: function (j, original_summary, cmdnum, attempts_left) {
 				let me = this;
 				$.post(me.api, {
@@ -397,6 +427,11 @@
 					last_sense: me.run.last_sense
 				}, function (d) {
 					$('#working').hide();
+					if (!d || !d.command) {
+						me.markCommandFailed(cmdnum, (d && d.status) || 'The command returned no result.');
+						setTimeout(function () {me.runNextCommand()}, me.direct_command_delay_ms);
+						return;
+					}
 					if (typeof d.command.message != 'undefined') d.command.meta.message = d.command.message;
 					d.command.summary = original_summary; // To remove the temporary_batch
 					Vue.set(me.meta.batch.data.commands, cmdnum, d.command);
@@ -424,20 +459,15 @@
 							return;
 						}
 						$('#working').hide();
-						if (typeof d.command.message != 'undefined') d.command.meta.message = d.command.message;
-						//				d.command.summary = original_summary ; // To remove the temporary_batch
-						//				Vue.set( me.meta.batch.data.commands, cmdnum, d.command ) ;
-						//				if ( typeof d.command.item != 'undefined' ) me.run.last_item = d.command.item ;
-						me.meta.commands.RUN--;
-
-						me.meta.batch.data.commands[cmdnum].meta.status = 'ERROR';
-						Vue.set(me.meta.commands, 'ERROR', (me.meta.commands.ERROR || 0) + 1);
+						let message = error || status || 'The command request failed.';
+						me.markCommandFailed(cmdnum, message);
 						setTimeout(function () {me.runNextCommand()}, me.direct_command_delay_ms);
 						me.run.last_ts = me.getTimestampNow();
 					});
 			},
 			runBatchDirectly: function () {
 				var me = this;
+				me.action_error = '';
 				if (!me.startRun(true)) return;
 				me.run.last_item = '';
 				me.run.last_form = '';
@@ -456,6 +486,7 @@
 
 			runBatchInBackground: function () {
 				var me = this;
+				me.action_error = '';
 				if (!me.startRun(false)) return;
 				if (me.meta.batch.id > 0) {
 					let params = {action: 'start_batch', batch: me.meta.batch.id};
@@ -463,7 +494,7 @@
 					$.get(me.api, params, function (d) {
 						$('#working').hide();
 						if (d.status != 'OK') {
-							alert(d.status);
+							me.action_error = 'The batch could not be started: ' + d.status;
 							console.log(d);
 							return;
 						}
@@ -487,7 +518,7 @@
 				$.post(me.api, params, function (d) {
 					$('#working').hide();
 					if (d.status != 'OK') {
-						alert(d.status);
+						me.action_error = 'The batch could not be started in the background: ' + d.status;
 						console.log(d);
 						return;
 					}

--- a/public_html/vue_components/batches.html
+++ b/public_html/vue_components/batches.html
@@ -1,11 +1,20 @@
 <template id='batches-template'>
-<div>
+<div class="qs-batches-page">
+	<div v-if="!loaded" class="qs-route-loading" aria-live="polite" aria-busy="true">
+		<div class="cdx-progress-bar cdx-progress-bar--inline" role="progressbar" aria-label="Loading latest batches"><div class="cdx-progress-bar__bar"></div></div>
+	</div>
+	<div v-else>
 	<h1>
-		<span tt='show_last_batches'></span>
+		<span v-if='typeof user_name=="undefined"'>Latest batches</span>
+		<span v-else>Latest batches</span>
 		<span v-if='typeof user_name!="undefined"'>
-			<span tt='for_user'></span> {{user_name}}
+			<span tt='for_user'></span> <bdi dir='auto'>{{user_name}}</bdi>
 		</span>
 	</h1>
+	<div v-if='load_error' class='qs-message qs-message--error qs-action-message' role='alert'>
+		<span class='qs-message__icon' aria-hidden='true'><svg class='cdx-icon cdx-icon--bidi-neutral' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><path d='M19.765 16.059 18 19H2L.235 16.059l8-15h3.53zM9 14v2h2v-2zm0-8v6h2V6z'></path></svg></span>
+		<span class='qs-message__content'><bdi dir='auto'>{{load_error}}</bdi></span>
+	</div>
 
 	<div v-if='!user.is_logged_in'>
 		<span tt='admin_hint'></span> <a href='./api.php?action=oauth_redirect'><span tt='login'></span></a>!
@@ -35,8 +44,8 @@
 						<span v-else>{{b.batch.status}}</span>
 					</div>
 					<div>
-						<span v-for='(num,cmd) in b.commands' style='margin-right:0.5rem;'>
-							<span :class="'badge badge-'+status_class[cmd]" style='font-weight:normal;'>{{cmd}}:{{num}}</span>
+						<span v-for='(num,cmd) in b.commands' style='margin-inline-end:0.5rem;'>
+							<span :class="'badge badge-'+status_class[cmd]">{{cmd}}:{{num}}</span>
 						</span>
 					</div>
 				</td>
@@ -56,6 +65,7 @@
 	</table>
 	<div v-else-if='!working' tt='no_batches'></div>
 
+	</div>
 </div>
 </template>
 
@@ -70,7 +80,7 @@ let BatchesPage = Vue.extend ( {
     	DONE:'success',
     	ERROR:'danger',
     	RUN:'info'
-    } , working:false , interval:'' , update_interval_ms:5000 } } ,
+    } , working:false , loaded:false , load_error:'' , interval:'' , update_interval_ms:5000 } } ,
     created : function () {
     	var me = this ;
     	me.loadBatches () ;
@@ -104,14 +114,12 @@ let BatchesPage = Vue.extend ( {
         loadBatches : function () {
             var me = this ;
             me.working = true ;
-            $('#working').show() ;
+			me.load_error = '' ;
             let params = { action:'get_batches_info' } ;
             if ( typeof me.user_name != "undefined" ) params.user = me.user_name ;
             $.get ( './api.php' , params , function ( d ) {
-            	me.working = false ;
-            	$('#working').hide() ;
             	if ( d.status != 'OK' ) {
-            		alert ( d.status ) ;
+					me.load_error = 'The batches could not be loaded: ' + d.status ;
             		return ;
             	}
             	let data = Object.values ( d.data ) ;
@@ -120,7 +128,10 @@ let BatchesPage = Vue.extend ( {
             	} ) ;
             	//console.log(JSON.parse(JSON.stringify(data)));
             	me.batches = data ;
-            } , 'json' ) ;
+            } , 'json' ).always ( function () {
+                me.working = false ;
+                me.loaded = true ;
+            } ) ;
         }
     },
     template:'#batches-template'

--- a/public_html/vue_components/command.html
+++ b/public_html/vue_components/command.html
@@ -2,27 +2,64 @@
 	div.command_row {
 		display: flex;
 		flex-direction: row;
+		flex-wrap: wrap;
 		flex: auto;
+		align-items: baseline;
+		padding-top: 0.5rem;
 	}
 
 	div.command_row:nth-child(even) {
-		background: #EEE;
+		background: var(--qs-background-neutral);
 	}
 
 	div.command_status {
 		display: flex;
-		width: 3em;
+		width: 14px;
+		height: var(--qs-line-height-small);
+		align-items: center;
+		justify-content: center;
 	}
+
+	.command_state {
+		display: inline-flex;
+		width: 12px;
+		height: 12px;
+		align-items: center;
+		justify-content: center;
+		transform: translateY(1px);
+	}
+
+	.command_state svg {
+		width: 12px;
+		height: 12px;
+		fill: currentColor;
+	}
+
+	.command_state--init { color: var(--qs-category-gray-400); }
+	.command_state--run { color: var(--qs-progressive-active); }
+	.command_state--done { color: var(--qs-content-added); }
+	.command_state--unchanged { color: var(--qs-icon-success); }
+	.command_state--error { color: var(--qs-destructive); }
+	.command_state--unknown { color: #72777d; }
 
 	div.command_action {
 		width: 4em;
 	}
 
+	div.command_action_cell {
+		padding: 1px 2px;
+	}
+
 	div.command_id {
 		display: flex;
-		width: 3em;
-		margin-right: 0.1rem;
-		font-family: monospace;
+		width: auto;
+		min-width: 4ch;
+		margin: 0;
+		padding-inline: 2px 8px;
+		font-family: var(--qs-font-monospace);
+		font-size: var(--qs-font-size-small);
+		line-height: var(--qs-line-height-small);
+		align-items: baseline;
 		justify-content: right;
 	}
 
@@ -34,6 +71,7 @@
 		display: flex;
 		flex-grow: 3;
 		flex-basis: 0;
+		align-items: baseline;
 	}
 
 	div.command_part {
@@ -57,6 +95,73 @@
 	div.qualifier_or_reference_column>div {
 		display: flex;
 		flex-direction: column;
+	}
+
+	div.command_message {
+		flex: 1 0 100%;
+		margin-block: 4px;
+		padding: 6px 8px;
+		border: 1px solid #c8ccd1;
+		border-inline-start: 3px solid #72777d;
+		background: #fff;
+		font-size: var(--qs-font-size-small);
+		line-height: var(--qs-line-height-small);
+		overflow-wrap: anywhere;
+	}
+
+	div.command_message--error {
+		border-inline-start-color: var(--qs-destructive);
+	}
+
+	div.command_message--unchanged {
+		border-inline-start-color: var(--qs-icon-success);
+	}
+
+	@media (max-width: 767px) {
+		div.command_row {
+			display: grid;
+			grid-template-columns: 14px max-content minmax(0, 1fr);
+			align-items: start;
+			row-gap: 4px;
+			width: 100%;
+		}
+
+		div.command_id,
+		div.command_status,
+		div.command_action {
+			width: auto;
+		}
+
+		div.command_item {
+			min-width: 0;
+			overflow-wrap: anywhere;
+		}
+
+		div.command_action_cell {
+			grid-column: 1 / 3;
+		}
+
+		div.command_details {
+			grid-column: 3;
+			min-width: 0;
+		}
+
+		div.command_message {
+			grid-column: 1 / -1;
+			margin-block: 2px 4px;
+		}
+
+		div.command_part {
+			flex-wrap: wrap;
+			min-width: 0;
+			overflow-wrap: anywhere;
+		}
+
+		div.command_what {
+			width: auto;
+			min-width: 0;
+			margin-inline-end: 4px;
+		}
 	}
 </style>
 
@@ -104,26 +209,22 @@
 
 <template id='command-template'>
 	<div class='command_row' :key='command.meta.id'>
+		<div class='command_status'>
+			<span class='command_state'
+				:class='"command_state--"+commandState'
+				:aria-label='commandStateLabel'
+				:title='commandStateTitle'
+				role='img'>
+				<svg v-if='commandState=="error"' viewBox='0 0 20 20' aria-hidden='true'><path d='M17.7575 6.04807c.3233-.32335.3233-.84759 0-1.17094l-2.6346-2.63462c-.3234-.32335-.8476-.32335-1.171 0L10.5855 5.609a.828.828 0 0 1-1.171 0L6.0481 2.2425c-.3234-.3233-.8476-.3233-1.171 0L2.2425 4.8771c-.3233.3234-.3233.8476 0 1.171L5.609 9.4145a.828.828 0 0 1 0 1.171l-3.3665 3.3664c-.3233.3234-.3233.8476 0 1.171l2.6346 2.6346c.3234.3233.8476.3233 1.171 0l3.3664-3.3665a.828.828 0 0 1 1.171 0l3.3664 3.3665c.3234.3233.8476.3233 1.171 0l2.6346-2.6346c.3233-.3234.3233-.8476 0-1.171l-3.3665-3.3664a.828.828 0 0 1 0-1.171z'/></svg>
+				<svg v-else-if='commandState=="unchanged"' viewBox='0 0 20 20' aria-hidden='true'><path d='M9.3572.5208c.194-.6944 1.0916-.6944 1.2856 0l1.325 4.7424c.1032.3696.4499.5888.7938.502l4.4123-1.1145c.6461-.1632 1.0949.6882.6428 1.2194l-3.0873 3.6279a.77.77 0 0 0 0 1.004l3.0873 3.6279c.4521.5312.0033 1.3826-.6428 1.2194l-4.4123-1.1144c-.3439-.0869-.6906.1323-.7938.502l-1.325 4.7423c-.194.6944-1.0916.6944-1.2856 0l-1.325-4.7423c-.1032-.3697-.4499-.5889-.7938-.502l-4.4123 1.1144c-.6461.1632-1.0949-.6882-.6428-1.2194l3.0873-3.6279a.77.77 0 0 0 0-1.004L2.1833 5.8701c-.4521-.5312-.0033-1.3826.6428-1.2194l4.4123 1.1145c.3439.0868.6906-.1324.7938-.502z'/></svg>
+				<svg v-else viewBox='0 0 20 20' aria-hidden='true'><path d='M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0'/></svg>
+			</span>
+		</div>
 		<div class='command_id'>
 			{{command.meta.id+1}}
 		</div>
-		<div class='command_status' :title='command.meta.message'>
-			<span v-if='typeof command.meta.status!="undefined"'>
-				<span v-if='command.meta.status=="INIT"'
-					class="badge badge-light">{{command.meta.status.toLowerCase()}}</span>
-				<span v-else-if='command.meta.status=="DONE"'
-					class="badge badge-success">{{command.meta.status.toLowerCase()}}</span>
-				<span v-else-if='command.meta.status=="ERROR"'
-					class="badge badge-danger">{{command.meta.status.toLowerCase()}}</span>
-				<span v-else class="badge badge-info">{{command.meta.status.toLowerCase()}}</span>
-			</span>
-			<span v-else>
-				TODO
-			</span>
-			<span v-if='typeof command.meta.message!="undefined" && command.meta.message!=""'>!</span>
-		</div>
 
-		<div class='command_auto_grow' style='flex-grow:1'>
+		<div class='command_auto_grow command_item' style='flex-grow:1'>
 			<div v-if='typeof command.item!="undefined"'>
 				<span v-if='site=="commons"'>
 					<span v-if='file_label==command.item'>
@@ -143,21 +244,21 @@
 			</div>
 		</div>
 
-		<div>
+		<div class='command_action_cell'>
 			<div v-if='typeof command.action!="undefined"' class='command_action'>
 				<span v-if='command.action.toUpperCase()=="ADD"'
-					class="badge badge-primary">{{command.action.toUpperCase()}}</span>
+					class="qs-action-badge qs-action-badge--add">{{command.action}}</span>
 				<span v-else-if='command.action.toUpperCase()=="CREATE"'
-					class="badge badge-success">{{command.action.toUpperCase()}}</span>
+					class="qs-action-badge qs-action-badge--create">{{command.action}}</span>
 				<span v-else-if='command.action.toUpperCase()=="MERGE"'
-					class="badge badge-warning">{{command.action.toUpperCase()}}</span>
+					class="qs-action-badge qs-action-badge--merge">{{command.action}}</span>
 				<span v-else-if='command.action.toUpperCase()=="REMOVE"'
-					class="badge badge-danger">{{command.action.toUpperCase()}}</span>
-				<span v-else class="badge badge-light">{{command.action.toUpperCase()}}</span>
+					class="qs-action-badge qs-action-badge--remove">{{command.action}}</span>
+				<span v-else class="qs-action-badge qs-action-badge--unknown">{{command.action}}</span>
 			</div>
 		</div>
 
-		<div v-if='command.action=="add"' class='command_auto_grow'>
+		<div v-if='command.action=="add"' class='command_auto_grow command_details'>
 
 			<div v-if='command.what=="statement"' class='command_part'>
 				<div class='command_what'>Statement</div>
@@ -249,7 +350,7 @@
 				{{command.summary}}
 			</div>
 		</div>
-		<div v-else-if='command.action=="merge" && command.type=="item"' class='command_auto_grow'>
+		<div v-else-if='command.action=="merge" && command.type=="item"' class='command_auto_grow command_details'>
 			<div class='command_what'>Item</div>
 			<div class='command_part'>
 				<div class='command_part2'><wd-link :item='command.item1' smallq='1'></wd-link></div>
@@ -261,7 +362,7 @@
 				{{command.summary}}
 			</div>
 		</div>
-		<div v-else-if='command.action=="create" && command.type=="item"' class='command_auto_grow'>
+		<div v-else-if='command.action=="create" && command.type=="item"' class='command_auto_grow command_details'>
 			<div class='command_what'>Item</div>
 			<div class='command_part' v-if='typeof command.data!="undefined"'>
 				<div style='display:flex;flex-direction:column;'>
@@ -306,7 +407,7 @@
 				</div>
 			</div>
 		</div>
-		<div v-else-if='command.action=="create" && command.type=="lexeme"' class='command_auto_grow'>
+		<div v-else-if='command.action=="create" && command.type=="lexeme"' class='command_auto_grow command_details'>
 			<div class='command_what'>Lexeme</div>
 			<div class='command_part' v-if='typeof command.data!="undefined"'>
 				<div style='display:flex;flex-direction:column;'>
@@ -328,7 +429,7 @@
 				{{command.summary}}
 			</div>
 		</div>
-		<div v-else-if='command.action=="create" && command.type=="form"' class='command_auto_grow'>
+		<div v-else-if='command.action=="create" && command.type=="form"' class='command_auto_grow command_details'>
 			<div class='command_what'>Form</div>
 			<div class='command_part' v-if='typeof command.data!="undefined"'>
 				<div style='display:flex;flex-direction:column;'>
@@ -350,7 +451,7 @@
 				{{command.summary}}
 			</div>
 		</div>
-		<div v-else-if='command.action=="create" && command.type=="sense"' class='command_auto_grow'>
+		<div v-else-if='command.action=="create" && command.type=="sense"' class='command_auto_grow command_details'>
 			<div class='command_what'>Sense</div>
 			<div class='command_part' v-if='typeof command.data!="undefined"'>
 				<div style='display:flex;flex-direction:column;'>
@@ -364,7 +465,7 @@
 				{{command.summary}}
 			</div>
 		</div>
-		<div v-else-if='command.action=="remove"' class='command_auto_grow'>
+		<div v-else-if='command.action=="remove"' class='command_auto_grow command_details'>
 			<div v-if='command.what=="statement"' class='command_part'>
 				<div class='command_what'>Statement</div>
 				<div class='command_part2'><wd-link :item='command.property' smallq='1'></wd-link></div>
@@ -372,9 +473,14 @@
 				<datavalue :dv='command.datavalue'></datavalue>
 			</div>
 		</div>
-		<div v-else class='command_auto_grow'>
+		<div v-else class='command_auto_grow command_details'>
 			<div>UNKNOWN COMMAND:</div>
 			{{command}}
+		</div>
+		<div v-if='typeof command.meta.message!="undefined" && command.meta.message!="" && commandState!="unchanged"' class='command_message'
+			:class='{"command_message--error":commandState=="error","command_message--unchanged":commandState=="unchanged"}'
+			:role='commandState=="error" ? "alert" : "status"'>
+			<bdi dir='auto'>{{command.meta.message}}</bdi>
 		</div>
 	</div>
 </template>
@@ -389,8 +495,7 @@
 		created: function () { },
 		updated: function () {tt.updateInterface(this.$el);},
 		mounted: function () {tt.updateInterface(this.$el);},
-		methods: {
-		},
+		methods: {},
 		template: '#datavalue-template'
 	});
 
@@ -406,7 +511,25 @@
 		},
 		updated: function () {tt.updateInterface(this.$el);},
 		mounted: function () {tt.updateInterface(this.$el);},
+		computed: {
+			commandState: function () {
+				if (this.isUnchangedSuccess()) return 'unchanged';
+				return (this.command.meta.status || 'unknown').toLowerCase();
+			},
+			commandStateLabel: function () {
+				if (this.commandState == 'unchanged') return 'Done; no change needed';
+				return this.commandState == 'unknown' ? 'Unknown status' : this.commandState;
+			},
+			commandStateTitle: function () {
+				if (this.commandState == 'unchanged' && this.command.meta.message) return this.command.meta.message;
+				return this.commandStateLabel;
+			}
+		},
 		methods: {
+			isUnchangedSuccess: function () {
+				if ((this.command.meta.status || '').toUpperCase() != 'DONE') return false;
+				return /already exists|already has|has already a qualifier/i.test(this.command.meta.message || '');
+			},
 			load_file_name_from_id: function (m) {
 				let me = this;
 				let page_id = m.replace(/\D/g, '');

--- a/public_html/vue_components/main-page.html
+++ b/public_html/vue_components/main-page.html
@@ -1,34 +1,38 @@
 <template id='main-page-template'>
-	<div class='container'>
+	<div class='container qs-home'>
         <div>
-            <p tt='intro'></p>
-            <div class="alert alert-primary" role="alert">
-                This is a new interface for QuickStatements V2.
-                Just in case, the old interface is <a href="./index_old.html" class="alert-link">here</a>.
-            </div>
-            <ul class="list-group list-group-flush">
-                <li class="list-group-item">
-                    <router-link class='btn btn-outline-primary' to='/batch' tt='new_batch'></router-link>
-                </li>
-                <li class="list-group-item">
-                    <form class='form-inline'>
-                        <input class='form-control' type='text' id='batch_id' tt_placeholder='ph_batchnumber' style='width:10em' v-model='batch_id' />
-                        <input class='btn btn-outline-primary' type='submit' tt_value='batch_details' @click.prevent='showBatch' />
+			<div v-if='page_error' class='qs-message qs-message--error qs-action-message' role='alert'>
+				<span class='qs-message__icon' aria-hidden='true'><svg class='cdx-icon cdx-icon--bidi-neutral' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><path d='M19.765 16.059 18 19H2L.235 16.059l8-15h3.53zM9 14v2h2v-2zm0-8v6h2V6z'></path></svg></span>
+				<span class='qs-message__content'><bdi dir='auto'>{{page_error}}</bdi></span>
+			</div>
+            <section class="qs-intro-card" aria-labelledby="qs-intro-title">
+                <div class="qs-intro-card__content">
+                    <h1 id="qs-intro-title">QuickStatements</h1>
+                    <p>QuickStatements lets you create and run batches of edits on Wikidata.</p>
+                    <p>Enter a set of commands, review the batch, and let the tool apply the statements for you.</p>
+                </div>
+                <router-link class="btn btn-primary qs-intro-card__action" to="/batch/new">New batch</router-link>
+            </section>
+            <section class="qs-manage" aria-labelledby="qs-manage-title">
+                <h2 id="qs-manage-title">Manage</h2>
+                <div class="qs-manage-grid">
+                    <form class="qs-manage-action">
+                        <label for="batch_id">Batch number</label>
+                        <input class="form-control" type="text" inputmode="numeric" id="batch_id" autocomplete="off" v-model="batch_id" />
+                        <button class="btn btn-primary" type="submit" @click.prevent="showBatch">See details</button>
                     </form>
-                </li>
-                <li class="list-group-item">
-                    <form class='form-inline'>
-                        <input class='form-control' type='text' id='user_name' tt_placeholder='ph_username' style='width:10em' v-model='username' />
-                        <input class='btn btn-outline-primary' type='submit' tt_value='batches_by_user' @click.prevent='showBatchesByUser' />
+                    <form class="qs-manage-action">
+                        <label for="user_name">User name</label>
+                        <input class="form-control" type="text" id="user_name" autocomplete="off" v-model="username" />
+                        <button class="btn btn-primary" type="submit" @click.prevent="showBatchesByUser">View batches</button>
                     </form>
-                </li>
-                <li class="list-group-item">
-                    <form class='form-inline'>
-                        <input class='form-control' type='text' tt_placeholder='ph_temp_batch_id' style='width:10em' v-model='temp_batch_id' />
-                        <input class='btn btn-outline-primary' type='submit' tt_value='temporary_batch_details' @click.prevent='showTemporaryBatch' />
+                    <form class="qs-manage-action">
+                        <label for="temp_batch_id">Temporary batch ID</label>
+                        <input class="form-control" type="text" inputmode="numeric" id="temp_batch_id" autocomplete="off" v-model="temp_batch_id" />
+                        <button class="btn btn-primary" type="submit" @click.prevent="showTemporaryBatch">Open</button>
                     </form>
-                </li>
-            </ul>
+                </div>
+            </section>
         </div>
 	</div>
 </template>
@@ -38,7 +42,7 @@
 
 let MainPage = Vue.extend ( {
         props : ['q','url_params'] ,
-        data : function () { return { batch_id:'',username:'',temp_batch_id:'' } } ,
+        data : function () { return { batch_id:'',username:'',temp_batch_id:'',page_error:'' } } ,
         created : function () {
             if ( typeof this.url_params != 'undefined' ) {
                 let m ;
@@ -70,6 +74,7 @@ let MainPage = Vue.extend ( {
             } ,
             createTemporaryBatch : function ( qs , format ) {
                 var me = this ;
+				me.page_error = '' ;
                 console.log ( qs ) ;
                 $.post ( './api.php' , {
                     action:'import',
@@ -79,7 +84,7 @@ let MainPage = Vue.extend ( {
                     format:format,
                 } , function ( d ) {
                     if ( d.status != 'OK' ) {
-                        alert ( "Error when trying to parse '+format.toUpperCase()+' URL data: "+d.status ) ;
+						me.page_error = 'The ' + format.toUpperCase() + ' commands in the URL could not be imported: ' + d.status ;
                         return ;
                     }
                     me.$router.push ( '/batch/?tempfile='+encodeURIComponent(d.data) );

--- a/public_html/vue_components/user.html
+++ b/public_html/vue_components/user.html
@@ -1,13 +1,10 @@
 <template id='user-template'>
-	<div>
-		<span v-if='is_logged_in'>
-			<router-link class="btn btn-outline-dark" to='/user'>{{getUserName()}}</router-link>
-			<router-link class="btn btn-outline-dark" :to='"/batches/"+getUserName()'
-				tt="show_your_last_batches"></router-link>
-		</span>
-		<span v-else>
-			<a href='./api.php?action=oauth_redirect'><span tt='login'></span></a>
-		</span>
+	<div class='qs-user-session'>
+		<router-link v-if='loaded && is_logged_in' class="qs-nav-link qs-nav-link--authorized" to='/user'>
+			<svg class="cdx-icon cdx-icon--bidi-neutral cdxIconUserActive" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><path d="M12 11a6 6 0 0 1 6 6v2H2v-2a6 6 0 0 1 6-6zM10 1a4 4 0 1 1 0 8 4 4 0 0 1 0-8"/></svg>
+			<span class="qs-nav-user-name">{{getUserName()}}</span>
+		</router-link>
+		<button v-if='loaded && is_logged_in' type='button' class='qs-nav-logout' @click='logout'>Log out</button>
 	</div>
 </template>
 
@@ -17,6 +14,13 @@
 
 	let user;
 
+	function normalizeToolTranslateLabels() {
+		let options = document.querySelectorAll('#tooltranslate_wrapper select option');
+		for (let option of options) {
+			if (option.textContent.trim() == 'AR') option.textContent = 'العربية';
+		}
+	}
+
 	Vue.component('user', {
 		data: function () {return {userinfo: {}, loaded: false, is_logged_in: false}},
 		created: function () {
@@ -24,8 +28,17 @@
 			this.loadData();
 		},
 		updated: function () {tt.updateInterface(this.$el);},
-		mounted: function () {tt.updateInterface(this.$el);},
+		mounted: function () {
+			tt.updateInterface(this.$el);
+			tt.addILdropdown('#tooltranslate_wrapper');
+			normalizeToolTranslateLabels();
+		},
 		methods: {
+			logout: function () {
+				$.post('./api.php', {action: 'logout'}, function () {
+					window.location.reload();
+				}, 'json');
+			},
 			loadData: function () {
 				let me = this;
 				$.get('./api.php', {
@@ -38,8 +51,18 @@
 					} else {
 						me.is_logged_in = false;
 					}
+				}, 'json').fail(function () {
+					me.is_logged_in = false;
+				}).always(function () {
 					me.loaded = true;
-				}, 'json');
+					me.$root.authLoaded = true;
+					me.$root.isLoggedIn = me.is_logged_in;
+					me.$root.userinfo = me.userinfo;
+					me.$nextTick(function () {
+						tt.updateInterface(me.$root.$el);
+						normalizeToolTranslateLabels();
+					});
+				});
 			},
 			isLoggedIn: function () {
 				return this.is_logged_in;


### PR DESCRIPTION
### Summary

- Modernized QuickStatements using Wikimedia Codex design patterns.
- Reworked responsive navigation, RTL behavior, language selection, user controls, footer links, and mobile layouts.
- Added clearer logged-in and logged-out states with OAuth testing support.
- Redesigned the new-batch form with explicit labels, project buttons, improved instructions, and separate command-import actions.
- Added Codex-style InfoChips, notices, buttons, icons, typography, inputs, and progress bars.
- Improved batch viewing with clearer command states, pagination, filters, run controls, status information, and inline errors.
- Distinguished added, unchanged, running, completed, and failed commands using accessible shapes and colors.
- Moved technical “statement already exists” details into the no-change asterisk tooltip.
- Added a completed-batch link to revert or discuss edits through EditGroups.
- Replaced native JavaScript alerts with visible interface notices.
- Improved API error handling so invalid server responses no longer hide useful errors.
- Added Wikimedia Commons as a selectable project.
- Added local configuration exclusions to prevent OAuth credentials and development settings from being committed.
- Added contributor guidance and a cache-aware Vue component loader.

### Verification

- PHP syntax checks passed.
- JavaScript syntax checks passed.
- `git diff --check` passed.
- No OAuth credentials or local configuration were committed.
- PHPUnit was unavailable in the checkout.
- Latest-batches loading cannot be fully tested locally because the Toolforge database is only reachable from the Toolforge network.