### PR TITLE
Polish batch navigation and status displays

### DIFF
--- a/public_html/api.php
+++ b/public_html/api.php
@@ -221,9 +221,7 @@ if ( $action == 'import' ) {
 
 	$db = $qs->getDB() ;
 	$sql = "SELECT * FROM command WHERE batch_id={$batch_id} AND num>={$start}" ; // num BETWEEN {$start} AND {$end}
-	if ( strtoupper(trim($filter)) == 'UNCHANGED' ) {
-		$sql .= " AND `status`='DONE' AND (`message` LIKE '%already exists%' OR `message` LIKE '%already has%' OR `message` LIKE '%has already a qualifier%')" ;
-	} else if ( $filter != '' ) {
+	if ( $filter != '' ) {
 		$filter = explode ( ',' , $filter ) ;
 		foreach ( $filter AS $k => $v ) {
 			$v = $db->real_escape_string ( trim ( strtoupper ( $v ) ) ) ;

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/magnustools/resources/html/wikimedia.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/oojs-ui/0.49.2/oojs-ui-wikimediaui.min.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/1.3.1/leaflet.css">
-<link rel="stylesheet" href="quickstatements.css?v=20260714-90">
+<link rel="stylesheet" href="quickstatements.css?v=20260714-91">
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/magnustools/resources/html/wikimedia.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/oojs-ui/0.49.2/oojs-ui-wikimediaui.min.css">
 <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/leaflet/1.3.1/leaflet.css">
-<link rel="stylesheet" href="quickstatements.css?v=20260714-85">
+<link rel="stylesheet" href="quickstatements.css?v=20260714-90">
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
 <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/vue/2.5.13/vue.min.js"></script>
@@ -86,9 +86,9 @@
 			<div v-if="!authLoaded" class="qs-loading" aria-live="polite" aria-busy="true">
 				<div class="cdx-progress-bar cdx-progress-bar--inline" role="progressbar" aria-label="Checking login"><div class="cdx-progress-bar__bar"></div></div>
 			</div>
-			<section v-else-if="!isLoggedIn" class="qs-login" aria-labelledby="qs-login-title">
+			<section v-else-if="!isLoggedIn && !isPublicRoute" class="qs-login" aria-labelledby="qs-login-title">
 				<h1 id="qs-login-title">QuickStatements</h1>
-				<p>Import and run batches of QuickStatements</p>
+				<p>QuickStatements lets you create and run batches of edits on Wikidata. Enter a set of commands, review the batch, and let the tool apply the statements for you.</p>
 				<a href="./api.php?action=oauth_redirect"
 					class="oo-ui-buttonElement oo-ui-widget oo-ui-widget-enabled oo-ui-buttonElement-framed oo-ui-flaggedElement-primary oo-ui-flaggedElement-progressive qs-login-button">
 					<span class="oo-ui-buttonElement-button" role="button">
@@ -117,6 +117,6 @@
 	</footer>
 </body>
 
-<script src="vue.js?v=20260714-08"></script>
+<script src="vue.js?v=20260714-09"></script>
 
 </html>

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -88,7 +88,7 @@
 			</div>
 			<section v-else-if="!isLoggedIn && !isPublicRoute" class="qs-login" aria-labelledby="qs-login-title">
 				<h1 id="qs-login-title">QuickStatements</h1>
-				<p>QuickStatements lets you create and run batches of edits on Wikidata. Enter a set of commands, review the batch, and let the tool apply the statements for you.</p>
+				<p>QuickStatements lets you create and run batches of edits on Wikidata and Wikimedia Commons. Enter a set of commands, review the batch, and let the tool apply the statements for you.</p>
 				<a href="./api.php?action=oauth_redirect"
 					class="oo-ui-buttonElement oo-ui-widget oo-ui-widget-enabled oo-ui-buttonElement-framed oo-ui-flaggedElement-primary oo-ui-flaggedElement-progressive qs-login-button">
 					<span class="oo-ui-buttonElement-button" role="button">

--- a/public_html/quickstatements.css
+++ b/public_html/quickstatements.css
@@ -1060,6 +1060,7 @@ body:has(.qs-route-loading) .qs-main {
 }
 
 .qs-batch-project legend,
+.qs-import-format legend,
 .qs-batch-name label,
 .qs-command-editor label {
 	display: block;
@@ -1154,6 +1155,10 @@ body:has(.qs-route-loading) .qs-main {
 .qs-import-actions {
 	margin-top: 8px;
 	text-align: start;
+}
+
+.qs-import-format {
+	margin: 0 0 8px;
 }
 
 .qs-import-progress {

--- a/public_html/quickstatements.css
+++ b/public_html/quickstatements.css
@@ -12,10 +12,12 @@
 	--qs-option-red: #bf3c2c;
 	--qs-option-lime: #1f7a39;
 	--qs-option-green: #177860;
+	--qs-option-blue: #36c;
 	--qs-option-purple: #6a60b0;
 	--qs-background-option-red: #ffe9e5;
 	--qs-background-option-lime: #e3f2e4;
 	--qs-background-option-green: #dff2eb;
+	--qs-background-option-blue: #e8eeff;
 	--qs-background-option-purple: #f0ecf6;
 	--qs-border: #a2a9b1;
 	--qs-border-subtle: #eaecf0;
@@ -52,7 +54,8 @@
 	--qs-font-weight-bold: 700;
 }
 
-.qs-action-badge {
+.qs-action-badge,
+.qs-info-chip {
 	display: inline-flex;
 	box-sizing: border-box;
 	min-height: 20px;
@@ -69,6 +72,36 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+.qs-batch-status-counts {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin-top: 4px;
+}
+
+.qs-info-chip {
+	text-transform: none;
+}
+
+.qs-info-chip--open,
+.qs-info-chip--running {
+	border-color: var(--qs-option-blue);
+	background: var(--qs-background-option-blue);
+	color: var(--qs-text);
+}
+
+.qs-info-chip--error {
+	border-color: var(--qs-option-red);
+	background: var(--qs-background-option-red);
+	color: var(--qs-text);
+}
+
+.qs-info-chip--done {
+	border-color: var(--qs-option-green);
+	background: var(--qs-background-option-green);
+	color: var(--qs-text);
 }
 
 .qs-action-badge--add {
@@ -594,6 +627,11 @@ html[dir="rtl"] #tooltranslate_wrapper select {
 	background: #fff;
 }
 
+.qs-home {
+	width: 100%;
+	max-width: none;
+}
+
 .qs-intro-card__content {
 	max-width: 75ch;
 	text-align: start;
@@ -978,6 +1016,20 @@ body:has(.qs-route-loading) .qs-main {
 
 .qs-main .table th {
 	font-weight: var(--qs-font-weight-semi-bold);
+}
+
+.qs-batches-page .table-striped tbody tr:nth-of-type(odd) {
+	background-color: var(--qs-background-neutral);
+}
+
+.qs-batches-page .table thead th {
+	border-top: 0;
+	border-bottom: 1px solid var(--qs-border);
+}
+
+.qs-batch-actions > div {
+	display: inline-flex;
+	margin-inline-end: 4px;
 }
 
 .qs-main .badge,
@@ -1432,6 +1484,17 @@ body:has(.qs-route-loading) .qs-main {
 	display: none;
 }
 
+@media (max-width: 900px) {
+	.qs-intro-card {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.qs-intro-card__action {
+		margin-inline-start: 0;
+	}
+}
+
 @media (max-width: 375px) {
 	.qs-import-actions__buttons {
 		display: flex;
@@ -1475,13 +1538,7 @@ body:has(.qs-route-loading) .qs-main {
 	}
 
 	.qs-intro-card {
-		align-items: flex-start;
-		flex-direction: column;
 		padding: 20px;
-	}
-
-	.qs-intro-card__action {
-		margin-inline-start: 0;
 	}
 
 	.qs-batch-setup {

--- a/public_html/vue.js
+++ b/public_html/vue.js
@@ -95,6 +95,11 @@ $(document).ready ( function () {
                 authLoaded : false,
                 isLoggedIn : false,
                 userinfo : {}
+			},
+			computed : {
+				isPublicRoute : function () {
+					return /^\/batches(?:\/|$)/.test(this.$route.path) ;
+				}
             }
         } ) .$mount('#app') ;
     } ) .catch ( error => {

--- a/public_html/vue_components/batch-commands.html
+++ b/public_html/vue_components/batch-commands.html
@@ -13,7 +13,6 @@ div.position_button_bar > div {
 	<div v-if='typeof batch!="undefined"' class='qs-command-filters qs-radio-buttons' role='radiogroup' aria-label='Command status'>
 		<label><input type='radio' v-model='view.filter' value='' @change='onFilterChange'><span>All</span></label>
 		<label><input type='radio' v-model='view.filter' value='INIT' @change='onFilterChange'><span>Open</span></label>
-		<label><input type='radio' v-model='view.filter' value='UNCHANGED' @change='onFilterChange'><span>Unchanged</span></label>
 		<label><input type='radio' v-model='view.filter' value='ERROR' @change='onFilterChange'><span>Errors</span></label>
 	</div>
 	<div class='qs-batch-commands-panel qs-command-list-shell'>
@@ -158,13 +157,8 @@ Vue.component ( 'batch-commands' , {
 			let me = this ;
 			if ( me.view.filter == '' ) return true ;
 			if ( typeof me.batch.data.commands[command_id] == 'undefined' ) return false ;
-			if ( me.view.filter == 'UNCHANGED' ) return me.isUnchangedCommand ( me.batch.data.commands[command_id] ) ;
 			if ( me.batch.data.commands[command_id].meta.status == me.view.filter ) return true ;
 			return false ;
-		} ,
-		isUnchangedCommand : function ( command ) {
-			if ( !command.meta || (command.meta.status || '').toUpperCase() != 'DONE' ) return false ;
-			return /already exists|already has|has already a qualifier/i.test(command.meta.message || '') ;
 		} ,
 		onFilterChange : function () {
 			this.view.position = 0 ;

--- a/public_html/vue_components/batch.html
+++ b/public_html/vue_components/batch.html
@@ -79,7 +79,7 @@
 					</div>
 				</div>
 				<div v-else-if='user.canCreateBatch()' class='create_batch_box'>
-					<form class='qs-new-batch-form' @submit.prevent='importV1'>
+					<form class='qs-new-batch-form' @submit.prevent='importSelectedFormat'>
 					<div class='qs-batch-setup'>
 						<fieldset class='qs-batch-project'>
 							<legend>Project</legend>
@@ -97,7 +97,7 @@
 						<div class='qs-batch-name'>
 							<label for='qs-batch-name'>Batch name</label>
 							<input id='qs-batch-name' type='text' class='form-control' v-model.trim='meta.batch.name'
-								@keydown.enter.prevent='importV1' />
+								@keydown.enter.prevent='importSelectedFormat' />
 						</div>
 					</div>
 
@@ -107,9 +107,21 @@
 							style='width:100%;'></textarea>
 					</div>
 					<div class='qs-import-actions'>
+						<fieldset class='qs-import-format'>
+							<legend>Format</legend>
+							<div class='qs-radio-buttons'>
+								<label>
+									<input type='radio' value='v1' v-model='import_format' />
+									<span>Commands</span>
+								</label>
+								<label>
+									<input type='radio' value='csv' v-model='import_format' />
+									<span>CSV</span>
+								</label>
+							</div>
+						</fieldset>
 						<div class='qs-import-actions__buttons'>
-							<button type='submit' class='btn btn-outline-primary' :disabled='importing'>Import commands</button>
-							<button type='button' class='btn btn-outline-primary' @click='importCSV' :disabled='importing'>Import CSV</button>
+							<button type='submit' class='btn btn-outline-primary' :disabled='importing'>Import</button>
 						</div>
 						<div v-if='importing' class='cdx-progress-bar cdx-progress-bar--inline qs-import-progress' role='progressbar'
 							aria-label='Importing commands' aria-busy='true'><div class='cdx-progress-bar__bar'></div></div>
@@ -159,7 +171,7 @@
 	let BatchPage = Vue.extend({
 		props: ['batch'],
 		mixins: [batch_access_mixin],
-		data: function () {return {api: './api.php', ready: false, commands: '', importing: false, import_error: '', action_error: '', run: {is_running_in_browser: false, last_item: '', last_form: '', last_sense: '', temp_id: '', start_ts: '', last_ts: ''}, direct_command_delay_ms: 1}},
+		data: function () {return {api: './api.php', ready: false, commands: '', import_format: 'v1', importing: false, import_error: '', action_error: '', run: {is_running_in_browser: false, last_item: '', last_form: '', last_sense: '', temp_id: '', start_ts: '', last_ts: ''}, direct_command_delay_ms: 1}},
 		created: function () {
 			var me = this;
 
@@ -213,6 +225,10 @@
 			}
 		},
 		methods: {
+			importSelectedFormat: function () {
+				if (this.import_format == 'csv') return this.importCSV();
+				return this.importV1();
+			},
 			updateWDforSite: function () {
 				var me = this;
 				let pb = config.sites[me.meta.batch.site].pageBase;

--- a/public_html/vue_components/batch.html
+++ b/public_html/vue_components/batch.html
@@ -279,11 +279,13 @@
 			importCSV: function () {
 				this.importCommands('csv');
 			},
-			importCommands: function (format, extraData) {
+			importCommands: function (format, extraData, isFormatFallback) {
 				var me = this;
-				if (me.importing) return;
-				me.import_error = '';
-				me.importing = true;
+				if (me.importing && !isFormatFallback) return;
+				if (!isFormatFallback) {
+					me.import_error = '';
+					me.importing = true;
+				}
 				let requestData = Object.assign({
 					action: 'import',
 					data: me.commands,
@@ -316,6 +318,11 @@
 				})
 				.then(function (d) {
 					if (!d.data || !d.data.commands || d.data.commands.length == 0) {
+						if (!isFormatFallback) {
+							let fallbackFormat = format == 'csv' ? 'v1' : 'csv';
+							let fallbackData = fallbackFormat == 'v1' ? {compress: 1} : {};
+							return me.importCommands(fallbackFormat, fallbackData, true);
+						}
 						me.import_error = "No valid commands were found.";
 						return;
 					}

--- a/public_html/vue_components/batches.html
+++ b/public_html/vue_components/batches.html
@@ -43,16 +43,17 @@
 						<span v-if='b.batch.status=="RUN" || b.batch.status=="INIT"'><b tt='running'></b></span>
 						<span v-else>{{b.batch.status}}</span>
 					</div>
-					<div>
-						<span v-for='(num,cmd) in b.commands' style='margin-inline-end:0.5rem;'>
-							<span :class="'badge badge-'+status_class[cmd]">{{cmd}}:{{num}}</span>
-						</span>
+					<div class='qs-batch-status-counts'>
+						<span v-if='(b.commands.INIT||0)>0' class='qs-info-chip qs-info-chip--open'>{{b.commands.INIT}} open</span>
+						<span v-if='(b.commands.RUN||0)>0' class='qs-info-chip qs-info-chip--running'>{{b.commands.RUN}} running</span>
+						<span v-if='(b.commands.ERROR||0)>0' class='qs-info-chip qs-info-chip--error'>{{b.commands.ERROR}} error<span v-if='b.commands.ERROR!=1'>s</span></span>
+						<span v-if='(b.commands.DONE||0)>0' class='qs-info-chip qs-info-chip--done'>{{b.commands.DONE}} done</span>
 					</div>
 				</td>
 				<td>
 					{{formatDate(b.batch.ts_last_change)}}
 				</td>
-				<td style='display:flex;flex-direction:row'>
+				<td class='qs-batch-actions'>
 					<div>
 						<a target='_blank' class='btn btn-outline-dark' :href='"https://editgroups.toolforge.org/b/QSv2/"+b.batch.id' tt='revert_batch'></a>
 					</div>
@@ -75,12 +76,7 @@
 
 let BatchesPage = Vue.extend ( {
     props : ['user_name'] ,
-    data : function () { return { batches:{} , status_class:{
-    	INIT:'primary',
-    	DONE:'success',
-    	ERROR:'danger',
-    	RUN:'info'
-    } , working:false , loaded:false , load_error:'' , interval:'' , update_interval_ms:5000 } } ,
+	data : function () { return { batches:{} , working:false , loaded:false , load_error:'' , interval:'' , update_interval_ms:5000 } } ,
     created : function () {
     	var me = this ;
     	me.loadBatches () ;

--- a/public_html/vue_components/command.html
+++ b/public_html/vue_components/command.html
@@ -521,7 +521,12 @@
 				return this.commandState == 'unknown' ? 'Unknown status' : this.commandState;
 			},
 			commandStateTitle: function () {
-				if (this.commandState == 'unchanged' && this.command.meta.message) return this.command.meta.message;
+				if (this.commandState == 'unchanged' && this.command.meta.message) {
+					return this.command.meta.message.replace(
+						/^The statement has already a reference with hash /i,
+						'The statement already has a reference with hash '
+					);
+				}
 				return this.commandStateLabel;
 			}
 		},

--- a/public_html/vue_components/command.html
+++ b/public_html/vue_components/command.html
@@ -528,7 +528,7 @@
 		methods: {
 			isUnchangedSuccess: function () {
 				if ((this.command.meta.status || '').toUpperCase() != 'DONE') return false;
-				return /already exists|already has|has already a qualifier/i.test(this.command.meta.message || '');
+				return /already exists|already has|has already (?:a qualifier|a reference)/i.test(this.command.meta.message || '');
 			},
 			load_file_name_from_id: function (m) {
 				let me = this;

--- a/public_html/vue_components/command.html
+++ b/public_html/vue_components/command.html
@@ -37,7 +37,7 @@
 
 	.command_state--init { color: var(--qs-category-gray-400); }
 	.command_state--run { color: var(--qs-progressive-active); }
-	.command_state--done { color: var(--qs-content-added); }
+	.command_state--done { color: var(--qs-icon-success); }
 	.command_state--unchanged { color: var(--qs-icon-success); }
 	.command_state--error { color: var(--qs-destructive); }
 	.command_state--unknown { color: #72777d; }

--- a/public_html/vue_components/main-page.html
+++ b/public_html/vue_components/main-page.html
@@ -8,7 +8,7 @@
             <section class="qs-intro-card" aria-labelledby="qs-intro-title">
                 <div class="qs-intro-card__content">
                     <h1 id="qs-intro-title">QuickStatements</h1>
-                    <p>QuickStatements lets you create and run batches of edits on Wikidata.</p>
+                    <p>QuickStatements lets you create and run batches of edits on Wikidata and Wikimedia Commons.</p>
                     <p>Enter a set of commands, review the batch, and let the tool apply the statements for you.</p>
                 </div>
                 <router-link class="btn btn-primary qs-intro-card__action" to="/batch/new">New batch</router-link>

--- a/public_html/vue_components/main-page.html
+++ b/public_html/vue_components/main-page.html
@@ -1,5 +1,5 @@
 <template id='main-page-template'>
-	<div class='container qs-home'>
+	<div class='qs-home'>
         <div>
 			<div v-if='page_error' class='qs-message qs-message--error qs-action-message' role='alert'>
 				<span class='qs-message__icon' aria-hidden='true'><svg class='cdx-icon cdx-icon--bidi-neutral' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><path d='M19.765 16.059 18 19H2L.235 16.059l8-15h3.53zM9 14v2h2v-2zm0-8v6h2V6z'></path></svg></span>

--- a/public_html/vue_components/user.html
+++ b/public_html/vue_components/user.html
@@ -14,13 +14,6 @@
 
 	let user;
 
-	function normalizeToolTranslateLabels() {
-		let options = document.querySelectorAll('#tooltranslate_wrapper select option');
-		for (let option of options) {
-			if (option.textContent.trim() == 'AR') option.textContent = 'العربية';
-		}
-	}
-
 	Vue.component('user', {
 		data: function () {return {userinfo: {}, loaded: false, is_logged_in: false}},
 		created: function () {
@@ -31,7 +24,6 @@
 		mounted: function () {
 			tt.updateInterface(this.$el);
 			tt.addILdropdown('#tooltranslate_wrapper');
-			normalizeToolTranslateLabels();
 		},
 		methods: {
 			logout: function () {
@@ -60,7 +52,6 @@
 					me.$root.userinfo = me.userinfo;
 					me.$nextTick(function () {
 						tt.updateInterface(me.$root.$el);
-						normalizeToolTranslateLabels();
 					});
 				});
 			},


### PR DESCRIPTION
- Allow logged-out users to view latest and user batch lists.
- Improve the logged-out introduction with clearer QuickStatements copy.
- Make the home-page layout responsive sooner while preserving the three Manage forms.
- Improve RTL-aware alignment for the New batch action.
- Display batch status totals as Codex-style pills: Open, Errors, and Done.
- Remove the undocumented Unchanged filter; unchanged commands remain Done with an asterisk in batch details.
- Fix latest-batches table borders, action-cell layout, and neutral zebra striping.
- Remove the hardcoded Arabic language-label workaround so it can be fixed upstream.